### PR TITLE
Add interface for std::span

### DIFF
--- a/fuzzing/fuzz_md5.cpp
+++ b/fuzzing/fuzz_md5.cpp
@@ -22,6 +22,11 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size
         std::string_view view {c_data_str};
         boost::crypt::md5(view);
         #endif
+
+        #ifdef BOOST_CRYPT_HAS_SPAN
+        std::span data_span {c_data, size};
+        boost::crypt::md5(data_span);
+        #endif
     }
     catch(...)
     {

--- a/fuzzing/fuzz_sha1.cpp
+++ b/fuzzing/fuzz_sha1.cpp
@@ -22,6 +22,11 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size
         std::string_view view {c_data_str};
         boost::crypt::sha1(view);
         #endif
+
+        #ifdef BOOST_CRYPT_HAS_SPAN
+        std::span data_span {c_data, size};
+        boost::crypt::sha1(data_span);
+        #endif
     }
     catch(...)
     {

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -731,7 +731,7 @@ constexpr auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_typ
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
 {
     return detail::md5(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -736,7 +736,7 @@ constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::retu
     return detail::md5(data.begin(), data.end());
 }
 
-#endif
+#endif // BOOST_CRYPT_HAS_CUDA
 
 } // namespace crypt
 } // namespace boost

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -716,6 +716,28 @@ inline auto md5_file(std::string_view filepath) noexcept -> md5_hasher::return_t
 
 #endif // BOOST_CRYPT_HAS_CUDA
 
+// ---- The CUDA versions that we support all offer <cuda/std/span> ----
+
+#ifdef BOOST_CRYPT_HAS_SPAN
+
+template <typename T, std::size_t extent>
+constexpr auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_type
+{
+    return detail::md5(data.begin(), data.end());
+}
+
+#endif // BOOST_CRYPT_HAS_SPAN
+
+#ifdef BOOST_CRYPT_HAS_CUDA
+
+template <typename T, boost::crypt::size_t extent>
+constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
+{
+    return detail::md5(data.begin(), data.end());
+}
+
+#endif
+
 } // namespace crypt
 } // namespace boost
 

--- a/include/boost/crypt/hash/sha1.hpp
+++ b/include/boost/crypt/hash/sha1.hpp
@@ -751,7 +751,7 @@ constexpr auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_t
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-constexpr auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
 {
     return detail::sha1(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha1.hpp
+++ b/include/boost/crypt/hash/sha1.hpp
@@ -735,6 +735,28 @@ inline auto sha1_file(std::string_view filepath) noexcept -> sha1_hasher::return
 
 #endif // BOOST_CRYPT_HAS_CUDA
 
+// ---- The CUDA versions that we support all offer <cuda/std/span> ----
+
+#ifdef BOOST_CRYPT_HAS_SPAN
+
+template <typename T, std::size_t extent>
+constexpr auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+{
+    return detail::sha1(data.begin(), data.end());
+}
+
+#endif // BOOST_CRYPT_HAS_SPAN
+
+#ifdef BOOST_CRYPT_HAS_CUDA
+
+template <typename T, boost::crypt::size_t extent>
+constexpr auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+{
+    return detail::sha1(data.begin(), data.end());
+}
+
+#endif // BOOST_CRYPT_HAS_CUDA
+
 } // namespace crypt
 } // namepsace boost
 

--- a/include/boost/crypt/hash/sha1.hpp
+++ b/include/boost/crypt/hash/sha1.hpp
@@ -330,7 +330,8 @@ constexpr auto sha1_hasher::sha1_update(ForwardIter data, boost::crypt::size_t s
 
     while (size-- && !corrupted)
     {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(*data & 0xFF);
+        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(static_cast<boost::crypt::uint8_t>(*data) &
+                                                                      static_cast<boost::crypt::uint8_t>(0xFF));
         low_ += 8U;
 
         if (BOOST_CRYPT_UNLIKELY(low_ == 0))

--- a/include/boost/crypt/utility/config.hpp
+++ b/include/boost/crypt/utility/config.hpp
@@ -71,10 +71,21 @@
 #      include <string_view>
 #      if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201606L
 #        define BOOST_CRYPT_HAS_STRING_VIEW
+#      endif // <string_view> macro check
+#    endif // Has <string_view>
+#  endif // C++17
+#endif // BOOST_CRYPT_HAS_CUDA
+
+// C++20
+#ifndef BOOST_CRYPT_HAS_CUDA
+#  if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#    if __has_include(<span>)
+#      if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
+#        define BOOST_CRYPT_HAS_SPAN
 #      endif
-#    endif
-#  endif
-#endif
+#    endif // Has <span>
+#  endif // C++20
+#endif // BOOST_CRYPT_HAS_CUDA
 
 #if defined(__has_builtin)
 #define BOOST_CRYPT_HAS_BUILTIN(x) __has_builtin(x)

--- a/include/boost/crypt/utility/config.hpp
+++ b/include/boost/crypt/utility/config.hpp
@@ -80,6 +80,7 @@
 #ifndef BOOST_CRYPT_HAS_CUDA
 #  if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #    if __has_include(<span>)
+#      include <span>
 #      if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
 #        define BOOST_CRYPT_HAS_SPAN
 #      endif

--- a/include/boost/crypt/utility/config.hpp
+++ b/include/boost/crypt/utility/config.hpp
@@ -36,6 +36,11 @@
 #  define BOOST_CRYPT_GPU_DEVICE_ENABLED
 #endif
 
+// Additional headers needed for CUDA
+#ifdef BOOST_CRYPT_HAS_CUDA
+#  include <cuda/std/span>
+#endif
+
 // ---- Constexpr arrays -----
 #if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
 #  define BOOST_CRYPT_CONSTEXPR_ARRAY inline constexpr

--- a/test/cover/make_gcov_02_files.gmk
+++ b/test/cover/make_gcov_02_files.gmk
@@ -8,7 +8,10 @@
 
 FILES_PRJ     := $(basename $(wildcard $(PATH_SRC)/*.cpp))
 
-FILES_EXCLUDE :=
+FILES_EXCLUDE :=  $(PATH_SRC)/test_md5_nvcc.cu          \
+                  $(PATH_SRC)/test_md5_nvrtc.cpp        \
+                  $(PATH_SRC)/test_sha1_nvcc.cu         \
+                  $(PATH_SRC)/test_sha1_nvrtc.cpp
 
 FILES_EXCLUDE := $(basename $(FILES_EXCLUDE))
 

--- a/test/test_md5.cpp
+++ b/test/test_md5.cpp
@@ -459,6 +459,8 @@ void test_invalid_state()
     BOOST_TEST(current_state == boost::crypt::hasher_state::null);
 }
 
+// This ends up being completely calculated in a constexpr fashion so Codecov complains
+// LCOV_EXCL_START
 void test_span()
 {
     #ifdef BOOST_CRYPT_HAS_SPAN
@@ -476,6 +478,7 @@ void test_span()
 
     #endif // BOOST_CRYPT_HAS_SPAN
 }
+// LCOV_EXCL_STOP
 
 int main()
 {

--- a/test/test_md5.cpp
+++ b/test/test_md5.cpp
@@ -459,6 +459,24 @@ void test_invalid_state()
     BOOST_TEST(current_state == boost::crypt::hasher_state::null);
 }
 
+void test_span()
+{
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    // "abc" in hex
+    const std::byte vals[] = {std::byte{0x61}, std::byte{0x62}, std::byte{0x63}};
+    std::span<const std::byte> byte_span {vals};
+    const auto expected_res = std::array<std::uint16_t, 16>{0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0, 0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
+    const auto res = boost::crypt::md5(byte_span);
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+}
+
 int main()
 {
     basic_tests();
@@ -488,6 +506,8 @@ int main()
     #endif
 
     test_invalid_state();
+
+    test_span();
 
     return boost::report_errors();
 }

--- a/test/test_sha1.cpp
+++ b/test/test_sha1.cpp
@@ -453,6 +453,25 @@ void test_invalid_state()
     BOOST_TEST(current_state == boost::crypt::hasher_state::null);
 }
 
+void test_span()
+{
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    // "abc" in hex
+    const std::byte vals[] = {std::byte{0x61}, std::byte{0x62}, std::byte{0x63}};
+    std::span<const std::byte> byte_span {vals};
+    const auto expected_res = std::array<std::uint16_t, 20>{0xA9, 0x99, 0x3E, 0x36, 0x47, 0x06, 0x81, 0x6A, 0xBA, 0x3E,
+                                                            0x25, 0x71, 0x78, 0x50, 0xC2, 0x6C, 0x9C, 0xD0, 0xD8, 0x9D};
+    const auto res = boost::crypt::sha1(byte_span);
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+}
+
 int main()
 {
     basic_tests();
@@ -479,6 +498,8 @@ int main()
     #endif
 
     test_invalid_state();
+
+    test_span();
 
     return boost::report_errors();
 }

--- a/test/test_sha1.cpp
+++ b/test/test_sha1.cpp
@@ -453,6 +453,8 @@ void test_invalid_state()
     BOOST_TEST(current_state == boost::crypt::hasher_state::null);
 }
 
+// This ends up being completely calculated in a constexpr fashion so Codecov complains
+// LCOV_EXCL_START
 void test_span()
 {
     #ifdef BOOST_CRYPT_HAS_SPAN
@@ -471,6 +473,7 @@ void test_span()
 
     #endif // BOOST_CRYPT_HAS_SPAN
 }
+// LCOV_EXCL_STOP
 
 int main()
 {


### PR DESCRIPTION
Test against `std::span<const std::byte>` to make sure we a) have compatibility with `std::byte` as the underlying type and b) DD on the ML said that `std::span<const std::byte>` is the way his company move around binary data.

Closes: #15 