### PR TITLE
Add a 512-bit hasher base class 

### DIFF
--- a/doc/crypt/md5.adoc
+++ b/doc/crypt/md5.adoc
@@ -21,25 +21,25 @@ namespace crypt {
 
 uisng return_type = boost::crypt::array<uint8_t, 16>;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const unsigned char* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const unsigned char* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const unsigned char* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const unsigned char* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str, size_t len) noexcept -> return_type;
 
 inline auto md5(const std::string& str) noexcept -> return_type;
 
@@ -64,14 +64,14 @@ inline auto md5(std::wstring_view str) noexcept -> return_type;
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 template <typename T, std::size_t extent>
-constexpr auto md5(std::span<T, extent> data) noexcept -> return_type;
+inline auto md5(std::span<T, extent> data) noexcept -> return_type;
 
 #endif // BOOST_CRYPT_HAS_SPAN
 
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
 
 #endif // BOOST_CRYPT_HAS_CUDA
 
@@ -118,12 +118,12 @@ class md5_hasher
     void init();
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
-    constexpr auto get_digest() noexcept -> return_type;
+    inline auto get_digest() noexcept -> return_type;
 };
 
 } // namespace crypt

--- a/doc/crypt/sha1.adoc
+++ b/doc/crypt/sha1.adoc
@@ -21,25 +21,25 @@ namespace crypt {
 
 uisng return_type = boost::crypt::array<uint8_t, 20>;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const unsigned char* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const unsigned char* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const unsigned char* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const unsigned char* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str, size_t len) noexcept -> return_type;
 
 inline auto sha1(const std::string& str) noexcept -> return_type;
 
@@ -64,14 +64,14 @@ inline auto sha1(std::wstring_view str) noexcept -> return_type;
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 template <typename T, std::size_t extent>
-constexpr auto md5(std::span<T, extent> data) noexcept -> return_type;
+inline auto md5(std::span<T, extent> data) noexcept -> return_type;
 
 #endif // BOOST_CRYPT_HAS_SPAN
 
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
 
 #endif // BOOST_CRYPT_HAS_CUDA
 
@@ -118,12 +118,12 @@ class sha1_hasher
     void init();
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
-    constexpr auto get_digest() noexcept -> boost::crypt::array<boost::crypt::uint8_t, 20>;
+    inline auto get_digest() noexcept -> boost::crypt::array<boost::crypt::uint8_t, 20>;
 };
 
 } // namespace crypt

--- a/doc/crypt/sha256.adoc
+++ b/doc/crypt/sha256.adoc
@@ -21,25 +21,25 @@ namespace crypt {
 
 uisng return_type = boost::crypt::array<uint8_t, 32>;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const unsigned char* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const unsigned char* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const unsigned char* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const unsigned char* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str, size_t len) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* str) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str) noexcept -> return_type;
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* str, size_t len) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str, size_t len) noexcept -> return_type;
 
 inline auto sha256(const std::string& str) noexcept -> return_type;
 
@@ -64,14 +64,14 @@ inline auto sha256(std::wstring_view str) noexcept -> return_type;
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 template <typename T, std::size_t extent>
-constexpr auto md5(std::span<T, extent> data) noexcept -> return_type;
+inline auto md5(std::span<T, extent> data) noexcept -> return_type;
 
 #endif // BOOST_CRYPT_HAS_SPAN
 
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
+BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
 
 #endif // BOOST_CRYPT_HAS_CUDA
 
@@ -118,12 +118,12 @@ class sha256_hasher
     void init();
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
-    constexpr auto get_digest() noexcept -> return_type;
+    inline auto get_digest() noexcept -> return_type;
 };
 
 } // namespace crypt

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -56,8 +56,10 @@ public:
 
 protected:
 
-    // This fucntion should be pure virtual but GCC < 9 won't accept that
+    // This function should be pure virtual but GCC < 9 won't accept that
+    // LCOV_EXCL_START
     virtual BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void {};
+    // LCOV_EXCL_STOP
 
     BOOST_CRYPT_GPU_ENABLED inline auto pad_message() noexcept -> void;
 

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -38,30 +38,30 @@ public:
 
     using return_type = boost::crypt::array<boost::crypt::uint8_t, digest_size>;
 
-    BOOST_CRYPT_GPU_ENABLED auto base_init() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED inline auto base_init() noexcept -> void;
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
-    virtual BOOST_CRYPT_GPU_ENABLED auto get_digest() noexcept -> return_type;
+    virtual BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
 
 protected:
 
-    virtual BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void = 0;
+    virtual BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void = 0;
 
-    BOOST_CRYPT_GPU_ENABLED auto pad_message() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED inline auto pad_message() noexcept -> void;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
 
     boost::crypt::array<boost::crypt::uint32_t, intermediate_hash_size> intermediate_hash_ {};
     boost::crypt::array<boost::crypt::uint8_t , 64U> buffer_ {};
@@ -73,7 +73,7 @@ protected:
 };
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::base_init() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::base_init() noexcept -> void
 {
     buffer_.fill(0);
     buffer_index_ = 0U;
@@ -85,7 +85,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ByteType>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_byte(ByteType byte) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_byte(ByteType byte) noexcept -> hasher_state
 {
     static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
     const auto value {static_cast<boost::crypt::uint8_t>(byte)};
@@ -94,7 +94,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     if (!utility::is_null(buffer))
     {
@@ -108,7 +108,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -140,7 +140,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -171,7 +171,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 }
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::get_digest() noexcept -> hasher_base_512<digest_size, intermediate_hash_size>::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::get_digest() noexcept -> hasher_base_512<digest_size, intermediate_hash_size>::return_type
 {
     hasher_base_512<digest_size, intermediate_hash_size>::return_type digest{};
 
@@ -200,7 +200,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 }
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::pad_message() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::pad_message() noexcept -> void
 {
     // 448 bits out of 512
     constexpr boost::crypt::size_t message_length_start_index {56U};
@@ -247,7 +247,7 @@ BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter>
-BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
 {
     if (size == 0U)
     {

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -38,30 +38,30 @@ public:
 
     using return_type = boost::crypt::array<boost::crypt::uint8_t, digest_size>;
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED auto base_init() noexcept -> void;
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type;
+    BOOST_CRYPT_GPU_ENABLED auto get_digest() noexcept -> return_type;
 
 protected:
 
-    virtual BOOST_CRYPT_GPU_ENABLED constexpr auto process_message_block() -> void = 0;
+    virtual BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void = 0;
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto pad_message() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED auto pad_message() noexcept -> void;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
 
     boost::crypt::array<boost::crypt::uint32_t, intermediate_hash_size> intermediate_hash_ {};
     boost::crypt::array<boost::crypt::uint8_t , 64U> buffer_ {};
@@ -76,7 +76,7 @@ private:
 };
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::init() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::base_init() noexcept -> void
 {
     buffer_.fill(0);
     buffer_index_ = 0U;
@@ -88,7 +88,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ByteType>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_byte(ByteType byte) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_byte(ByteType byte) noexcept -> hasher_state
 {
     static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
     const auto value {static_cast<boost::crypt::uint8_t>(byte)};
@@ -97,7 +97,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     if (!utility::is_null(buffer))
     {
@@ -111,7 +111,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -143,7 +143,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -174,7 +174,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 }
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::get_digest() noexcept -> hasher_base_512<digest_size, intermediate_hash_size>::return_type
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::get_digest() noexcept -> hasher_base_512<digest_size, intermediate_hash_size>::return_type
 {
     hasher_base_512<digest_size, intermediate_hash_size>::return_type digest{};
 
@@ -203,7 +203,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 }
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::pad_message() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::pad_message() noexcept -> void
 {
     // 448 bits out of 512
     constexpr boost::crypt::size_t message_length_start_index {56U};
@@ -250,7 +250,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename ForwardIter>
-BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED auto hasher_base_512<digest_size, intermediate_hash_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
 {
     if (size == 0U)
     {

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -1,0 +1,302 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_CRYPT_HASH_DETAIL_HASHER_BASE_512_HPP
+#define BOOST_CRYPT_HASH_DETAIL_HASHER_BASE_512_HPP
+
+#include <boost/crypt/hash/hasher_state.hpp>
+#include <boost/crypt/utility/config.hpp>
+#include <boost/crypt/utility/bit.hpp>
+#include <boost/crypt/utility/byte.hpp>
+#include <boost/crypt/utility/array.hpp>
+#include <boost/crypt/utility/cstdint.hpp>
+#include <boost/crypt/utility/type_traits.hpp>
+#include <boost/crypt/utility/strlen.hpp>
+#include <boost/crypt/utility/cstddef.hpp>
+#include <boost/crypt/utility/iterator.hpp>
+#include <boost/crypt/utility/file.hpp>
+#include <boost/crypt/utility/null.hpp>
+
+#if !defined(BOOST_CRYPT_BUILD_MODULE) && !defined(BOOST_CRYPT_HAS_CUDA)
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <cstring>
+#endif
+
+namespace boost {
+namespace crypt {
+namespace hash_detail {
+
+// This hasher base is for use processing 512-bit blocks at a time
+template <boost::crypt::size_t digest_size,
+          boost::crypt::size_t intermediate_hash_size>
+class hasher_base_512
+{
+public:
+
+    using return_type = boost::crypt::array<boost::crypt::uint8_t, digest_size>;
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void;
+
+    template <typename ByteType>
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
+
+    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+
+    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+
+    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type;
+
+protected:
+
+    virtual BOOST_CRYPT_GPU_ENABLED constexpr auto process_message_block() -> void = 0;
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto pad_message() noexcept -> void;
+
+    template <typename ForwardIter>
+    BOOST_CRYPT_GPU_ENABLED constexpr auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
+
+    boost::crypt::array<boost::crypt::uint32_t, intermediate_hash_size> intermediate_hash_ {};
+    boost::crypt::array<boost::crypt::uint8_t , 64U> buffer_ {};
+    boost::crypt::size_t buffer_index_ {};
+
+private:
+
+    boost::crypt::size_t low_ {};
+    boost::crypt::size_t high_ {};
+    bool computed {};
+    bool corrupted {};
+};
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::init() noexcept -> void
+{
+    buffer_.fill(0);
+    buffer_index_ = 0U;
+    low_ = 0U;
+    high_ = 0U;
+    computed = false;
+    corrupted = false;
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename ByteType>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_byte(ByteType byte) noexcept -> hasher_state
+{
+    static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
+    const auto value {static_cast<boost::crypt::uint8_t>(byte)};
+    return update(&value, 1UL);
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+{
+    if (!utility::is_null(buffer))
+    {
+        return update(buffer, byte_count);
+    }
+    else
+    {
+        return hasher_state::null;
+    }
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+{
+    #ifndef BOOST_CRYPT_HAS_CUDA
+
+    if (!utility::is_null(buffer))
+    {
+        const auto* char_ptr {reinterpret_cast<const char *>(std::addressof(*buffer))};
+        const auto* data {reinterpret_cast<const unsigned char *>(char_ptr)};
+        return update(data, byte_count * 2U);
+    }
+    else
+    {
+        return hasher_state::null;
+    }
+
+    #else
+
+    if (!utility::is_null(buffer))
+    {
+        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
+        return update(data, byte_count * 2U);
+    }
+    else
+    {
+        return hasher_state::null;
+    }
+
+    #endif
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+{
+    #ifndef BOOST_CRYPT_HAS_CUDA
+
+    if (!utility::is_null(buffer))
+    {
+        const auto* char_ptr {reinterpret_cast<const char *>(std::addressof(*buffer))};
+        const auto* data {reinterpret_cast<const unsigned char *>(char_ptr)};
+        return update(data, byte_count * 4U);
+    }
+    else
+    {
+        return hasher_state::null;
+    }
+
+    #else
+
+    if (!utility::is_null(buffer))
+    {
+        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
+        return update(data, byte_count * 4U);
+    }
+    else
+    {
+        return hasher_state::null;
+    }
+
+    #endif
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::get_digest() noexcept -> hasher_base_512<digest_size, intermediate_hash_size>::return_type
+{
+    hasher_base_512<digest_size, intermediate_hash_size>::return_type digest{};
+
+    if (corrupted)
+    {
+        // Return empty message on corruption
+        return digest;
+    }
+    if (!computed)
+    {
+        pad_message();
+
+        // Overwrite whatever is in the buffer in case it is sensitive
+        buffer_.fill(0);
+        low_ = 0U;
+        high_ = 0U;
+        computed = true;
+    }
+
+    for (boost::crypt::size_t i {}; i < digest.size(); ++i)
+    {
+        digest[i] = static_cast<boost::crypt::uint8_t>(intermediate_hash_[i >> 2U] >> 8U * (3U - (i & 0x03U)));
+    }
+
+    return digest;
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::pad_message() noexcept -> void
+{
+    // 448 bits out of 512
+    constexpr boost::crypt::size_t message_length_start_index {56U};
+
+    // We don't have enough space for everything we need
+    if (buffer_index_ >= message_length_start_index)
+    {
+        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x80);
+        while (buffer_index_ < buffer_.size())
+        {
+            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
+        }
+
+        process_message_block();
+
+        while (buffer_index_ < message_length_start_index)
+        {
+            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
+        }
+    }
+    else
+    {
+        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x80);
+        while (buffer_index_ < message_length_start_index)
+        {
+            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
+        }
+    }
+
+    // Add the message length to the end of the buffer
+    BOOST_CRYPT_ASSERT(buffer_index_ == message_length_start_index);
+
+    buffer_[56U] = static_cast<boost::crypt::uint8_t>(high_ >> 24U);
+    buffer_[57U] = static_cast<boost::crypt::uint8_t>(high_ >> 16U);
+    buffer_[58U] = static_cast<boost::crypt::uint8_t>(high_ >>  8U);
+    buffer_[59U] = static_cast<boost::crypt::uint8_t>(high_);
+    buffer_[60U] = static_cast<boost::crypt::uint8_t>(low_ >> 24U);
+    buffer_[61U] = static_cast<boost::crypt::uint8_t>(low_ >> 16U);
+    buffer_[62U] = static_cast<boost::crypt::uint8_t>(low_ >>  8U);
+    buffer_[63U] = static_cast<boost::crypt::uint8_t>(low_);
+
+    process_message_block();
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename ForwardIter>
+BOOST_CRYPT_GPU_ENABLED constexpr auto hasher_base_512<digest_size, intermediate_hash_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
+{
+    if (size == 0U)
+    {
+        return hasher_state::success;
+    }
+    if (computed)
+    {
+        corrupted = true;
+    }
+    if (corrupted)
+    {
+        return hasher_state::state_error;
+    }
+
+    while (size--)
+    {
+        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(static_cast<boost::crypt::uint8_t>(*data) &
+                                                                      static_cast<boost::crypt::uint8_t>(0xFF));
+        low_ += 8U;
+
+        if (BOOST_CRYPT_UNLIKELY(low_ == 0))
+        {
+            // Would indicate size_t rollover which should not happen on a single data stream
+            // LCOV_EXCL_START
+            ++high_;
+            if (BOOST_CRYPT_UNLIKELY(high_ == 0))
+            {
+                corrupted = true;
+                return hasher_state::input_too_long;
+            }
+            // LCOV_EXCL_STOP
+        }
+
+        if (buffer_index_ == buffer_.size())
+        {
+            process_message_block();
+        }
+
+        ++data;
+    }
+
+    return hasher_state::success;
+}
+
+} // namespace hash_detail
+} // namespace crypt
+} // namespace boost
+
+#endif //BOOST_CRYPT_HASH_DETAIL_HASHER_BASE_512_HPP

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -56,7 +56,8 @@ public:
 
 protected:
 
-    virtual BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void = 0;
+    // This fucntion should be pure virtual but GCC < 9 won't accept that
+    virtual BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void {};
 
     BOOST_CRYPT_GPU_ENABLED inline auto pad_message() noexcept -> void;
 

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -52,7 +52,7 @@ public:
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
     BOOST_CRYPT_GPU_ENABLED auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
-    BOOST_CRYPT_GPU_ENABLED auto get_digest() noexcept -> return_type;
+    virtual BOOST_CRYPT_GPU_ENABLED auto get_digest() noexcept -> return_type;
 
 protected:
 
@@ -66,9 +66,6 @@ protected:
     boost::crypt::array<boost::crypt::uint32_t, intermediate_hash_size> intermediate_hash_ {};
     boost::crypt::array<boost::crypt::uint8_t , 64U> buffer_ {};
     boost::crypt::size_t buffer_index_ {};
-
-private:
-
     boost::crypt::size_t low_ {};
     boost::crypt::size_t high_ {};
     bool computed {};

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -39,11 +39,11 @@ public:
 
     BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED auto get_digest() noexcept -> return_type override;
+    BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type override;
 
 private:
 
-    BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void override;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void override;
 };
 
 BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::init() noexcept -> void
@@ -110,7 +110,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto II(boost::crypt::uint32_t& a, boost::crypt::
 
 } // md5_body_detail
 
-BOOST_CRYPT_GPU_ENABLED auto md5_hasher::process_message_block() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_message_block() noexcept -> void
 {
     using namespace md5_body_detail;
 

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_CRYPT_HASH_MD5_HPP
 #define BOOST_CRYPT_HASH_MD5_HPP
 
+#include <boost/crypt/hash/detail/hasher_base_512.hpp>
 #include <boost/crypt/hash/hasher_state.hpp>
 #include <boost/crypt/utility/config.hpp>
 #include <boost/crypt/utility/bit.hpp>
@@ -30,301 +31,29 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class md5_hasher
+BOOST_CRYPT_EXPORT class md5_hasher : public hash_detail::hasher_base_512<16U, 4U>
 {
-private:
-    boost::crypt::uint32_t a0_ {0x67452301};
-    boost::crypt::uint32_t b0_ {0xefcdab89};
-    boost::crypt::uint32_t c0_ {0x98badcfe};
-    boost::crypt::uint32_t d0_ {0x10325476};
-
-    boost::crypt::size_t low_ {};
-    boost::crypt::size_t high_ {};
-
-    boost::crypt::array<boost::crypt::uint8_t, 64> buffer_ {};
-    boost::crypt::array<boost::crypt::uint32_t, 16> blocks_ {};
-
-    bool computed {};
-    bool corrupted {};
-
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED inline auto md5_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
-
-    BOOST_CRYPT_GPU_ENABLED inline auto md5_convert_buffer_to_blocks() noexcept;
-
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED inline auto md5_copy_data(ForwardIter data, boost::crypt::size_t offset, boost::crypt::size_t size) noexcept;
-
-    BOOST_CRYPT_GPU_ENABLED inline auto md5_body() noexcept -> void;
-
 public:
 
-    using return_type = boost::crypt::array<boost::crypt::uint8_t, 16>;
-
-    BOOST_CRYPT_GPU_ENABLED inline md5_hasher() noexcept { this-> init(); }
+    BOOST_CRYPT_GPU_ENABLED md5_hasher() noexcept { this->init(); }
 
     BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
 
-    template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED auto get_digest() noexcept -> return_type override;
 
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+private:
 
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-    BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
+    BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void override;
 };
 
 BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::init() noexcept -> void
 {
-    a0_ = 0x67452301U;
-    b0_ = 0xefcdab89U;
-    c0_ = 0x98badcfeU;
-    d0_ = 0x10325476U;
+    hash_detail::hasher_base_512<16U, 4U>::base_init();
 
-    low_ = 0U;
-    high_ = 0U;
-
-    buffer_.fill(static_cast<boost::crypt::uint8_t>(0));
-    blocks_.fill(0U);
-
-    computed = false;
-    corrupted = false;
-}
-
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_convert_buffer_to_blocks() noexcept
-{
-    boost::crypt::size_t buffer_index {};
-    for (auto& block : blocks_)
-    {
-        block = static_cast<boost::crypt::uint32_t>(
-                static_cast<boost::crypt::uint32_t>(buffer_[buffer_index]) |
-                (static_cast<boost::crypt::uint32_t>(buffer_[buffer_index + 1U]) << 8U) |
-                (static_cast<boost::crypt::uint32_t>(buffer_[buffer_index + 2U]) << 16U) |
-                (static_cast<boost::crypt::uint32_t>(buffer_[buffer_index + 3U]) << 24U)
-        );
-
-        buffer_index += 4U;
-    }
-}
-
-template <typename ForwardIter>
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_copy_data(ForwardIter data, boost::crypt::size_t offset, boost::crypt::size_t size) noexcept
-{
-    for (boost::crypt::size_t i {}; i < size; ++i)
-    {
-        BOOST_CRYPT_ASSERT(offset + i < buffer_.size());
-        buffer_[offset + i] = static_cast<boost::crypt::uint8_t>(*(data + static_cast<boost::crypt::ptrdiff_t>(i)));
-    }
-}
-
-template <typename ForwardIter>
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
-{
-    if (size == 0U)
-    {
-        return hasher_state::success;
-    }
-    if (computed)
-    {
-        corrupted = true;
-    }
-    if (corrupted)
-    {
-        return hasher_state::state_error;
-    }
-
-    const auto input_bits {size << 3U}; // Convert size to bits
-    const auto old_low {low_};
-    low_ += input_bits;
-    if (low_ < old_low)
-    {
-        // This should never happen as it indicates size_t roll over
-        // LCOV_EXCL_START
-        ++high_;
-        if (high_ == 0U)
-        {
-            corrupted = true;
-            return hasher_state::input_too_long;
-        }
-        // LCOV_EXCL_STOP
-    }
-    high_ += size >> 29U;
-
-    auto used {(old_low >> 3U) & 0x3F}; // Number of bytes used in buffer
-
-    if (used)
-    {
-        auto available = 64U - used;
-        if (size < available)
-        {
-            md5_copy_data(data, used, size);
-            return hasher_state::success;
-        }
-
-        md5_copy_data(data, used, available);
-        md5_convert_buffer_to_blocks();
-        md5_body();
-        data += static_cast<boost::crypt::ptrdiff_t>(available);
-        size -= available;
-    }
-
-    while (size >= 64U)
-    {
-        md5_copy_data(data, 0U, 64U);
-        md5_convert_buffer_to_blocks();
-        md5_body();
-        data += 64U;
-        size -= 64U;
-    }
-
-    if (size > 0)
-    {
-        md5_copy_data(data, 0U, size);
-    }
-
-    return hasher_state::success;
-}
-
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::get_digest() noexcept -> return_type
-{
-    return_type digest {};
-    if (corrupted)
-    {
-        return digest;
-    }
-
-    auto used {(low_ >> 3U) & 0x3F}; // Number of bytes used in buffer
-    buffer_[used++] = 0x80;
-    auto available {buffer_.size() - used};
-
-    if (available < 8U)
-    {
-        fill_array(buffer_.begin() + used, buffer_.end(), static_cast<boost::crypt::uint8_t>(0));
-        md5_convert_buffer_to_blocks();
-        md5_body();
-        used = 0;
-        buffer_.fill(0);
-    }
-    else
-    {
-        fill_array(buffer_.begin() + used, buffer_.end() - 8, static_cast<boost::crypt::uint8_t>(0));
-    }
-
-    const auto total_bits {(static_cast<uint64_t>(high_) << 32) | low_};
-
-    // Append the length in bits as a 64-bit little-endian integer
-    buffer_[56] = static_cast<boost::crypt::uint8_t>(total_bits & 0xFF);
-    buffer_[57] = static_cast<boost::crypt::uint8_t>((total_bits >> 8) & 0xFF);
-    buffer_[58] = static_cast<boost::crypt::uint8_t>((total_bits >> 16) & 0xFF);
-    buffer_[59] = static_cast<boost::crypt::uint8_t>((total_bits >> 24) & 0xFF);
-    buffer_[60] = static_cast<boost::crypt::uint8_t>((total_bits >> 32) & 0xFF);
-    buffer_[61] = static_cast<boost::crypt::uint8_t>((total_bits >> 40) & 0xFF);
-    buffer_[62] = static_cast<boost::crypt::uint8_t>((total_bits >> 48) & 0xFF);
-    buffer_[63] = static_cast<boost::crypt::uint8_t>((total_bits >> 56) & 0xFF);
-
-    md5_convert_buffer_to_blocks();
-    md5_body();
-    computed = true;
-
-    for (boost::crypt::size_t i = 0; i < 4; ++i)
-    {
-        const auto value {(i == 0 ? a0_ : (i == 1 ? b0_ : (i == 2 ? c0_ : d0_)))};
-        digest[i*4]     = static_cast<boost::crypt::uint8_t>(value & 0xFF);
-        digest[i*4 + 1] = static_cast<boost::crypt::uint8_t>((value >> 8U) & 0xFF);
-        digest[i*4 + 2] = static_cast<boost::crypt::uint8_t>((value >> 16U) & 0xFF);
-        digest[i*4 + 3] = static_cast<boost::crypt::uint8_t>((value >> 24U) & 0xFF);
-    }
-
-    return digest;
-}
-
-template <typename ByteType>
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_byte(ByteType byte) noexcept -> hasher_state
-{
-    static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
-    const auto value {static_cast<boost::crypt::uint8_t>(byte)};
-    return md5_update(&value, 1UL);
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    if (!utility::is_null(buffer))
-    {
-        return md5_update(buffer, byte_count);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    #ifndef BOOST_CRYPT_HAS_CUDA
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* char_ptr {reinterpret_cast<const char*>(std::addressof(*buffer))};
-        const auto* data {reinterpret_cast<const unsigned char*>(char_ptr)};
-        return md5_update(data, byte_count * 2U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #else
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
-        return md5_update(data, byte_count * 2U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #endif
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    #ifndef BOOST_CRYPT_HAS_CUDA
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* char_ptr {reinterpret_cast<const char*>(std::addressof(*buffer))};
-        const auto* data {reinterpret_cast<const unsigned char*>(char_ptr)};
-        return md5_update(data, byte_count * 4U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #else
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
-        return md5_update(data, byte_count * 4U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #endif
+    intermediate_hash_[0] = 0x67452301;
+    intermediate_hash_[1] = 0xefcdab89;
+    intermediate_hash_[2] = 0x98badcfe;
+    intermediate_hash_[3] = 0x10325476;
 }
 
 // See: Applied Cryptography - Bruce Schneier
@@ -352,120 +81,188 @@ BOOST_CRYPT_GPU_ENABLED inline auto I(boost::crypt::uint32_t x, boost::crypt::ui
 }
 
 BOOST_CRYPT_GPU_ENABLED inline auto FF(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
-                                          boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
-                                          boost::crypt::uint32_t ti) noexcept
+                                       boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
+                                       boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + F(b, c, d) + Mj + ti), si);
 }
 
 BOOST_CRYPT_GPU_ENABLED inline auto GG(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
-                                          boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
-                                          boost::crypt::uint32_t ti) noexcept
+                                       boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
+                                       boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + G(b, c, d) + Mj + ti), si);
 }
 
 BOOST_CRYPT_GPU_ENABLED inline auto HH(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
-                                          boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
-                                          boost::crypt::uint32_t ti) noexcept
+                                       boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
+                                       boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + H(b, c, d) + Mj + ti), si);
 }
 
 BOOST_CRYPT_GPU_ENABLED inline auto II(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
-                                          boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
-                                          boost::crypt::uint32_t ti) noexcept
+                                       boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
+                                       boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + I(b, c, d) + Mj + ti), si);
 }
 
 } // md5_body_detail
 
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_body() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED auto md5_hasher::process_message_block() noexcept -> void
 {
     using namespace md5_body_detail;
 
-    boost::crypt::uint32_t a {a0_};
-    boost::crypt::uint32_t b {b0_};
-    boost::crypt::uint32_t c {c0_};
-    boost::crypt::uint32_t d {d0_};
+    boost::crypt::array<boost::crypt::uint32_t, 16> blocks {};
+
+    // Convert the buffer into 32-bit blocks for hashing
+    boost::crypt::size_t index {};
+    for (auto& block : blocks)
+    {
+        block = static_cast<boost::crypt::uint32_t>(
+                static_cast<boost::crypt::uint32_t>(buffer_[index]) |
+                (static_cast<boost::crypt::uint32_t>(buffer_[index + 1U]) << 8U) |
+                (static_cast<boost::crypt::uint32_t>(buffer_[index + 2U]) << 16U) |
+                (static_cast<boost::crypt::uint32_t>(buffer_[index + 3U]) << 24U)
+        );
+
+        index += 4U;
+    }
+
+    auto a {intermediate_hash_[0]};
+    auto b {intermediate_hash_[1]};
+    auto c {intermediate_hash_[2]};
+    auto d {intermediate_hash_[3]};
 
     // Round 1
-    FF(a, b, c, d, blocks_[0],   7, 0xd76aa478);
-    FF(d, a, b, c, blocks_[1],  12, 0xe8c7b756);
-    FF(c, d, a, b, blocks_[2],  17, 0x242070db);
-    FF(b, c, d, a, blocks_[3],  22, 0xc1bdceee);
-    FF(a, b, c, d, blocks_[4],   7, 0xf57c0faf);
-    FF(d, a, b, c, blocks_[5],  12, 0x4787c62a);
-    FF(c, d, a, b, blocks_[6],  17, 0xa8304613);
-    FF(b, c, d, a, blocks_[7],  22, 0xfd469501);
-    FF(a, b, c, d, blocks_[8],   7, 0x698098d8);
-    FF(d, a, b, c, blocks_[9],  12, 0x8b44f7af);
-    FF(c, d, a, b, blocks_[10], 17, 0xffff5bb1);
-    FF(b, c, d, a, blocks_[11], 22, 0x895cd7be);
-    FF(a, b, c, d, blocks_[12],  7, 0x6b901122);
-    FF(d, a, b, c, blocks_[13], 12, 0xfd987193);
-    FF(c, d, a, b, blocks_[14], 17, 0xa679438e);
-    FF(b, c, d, a, blocks_[15], 22, 0x49b40821);
+    FF(a, b, c, d, blocks[0],   7, 0xd76aa478);
+    FF(d, a, b, c, blocks[1],  12, 0xe8c7b756);
+    FF(c, d, a, b, blocks[2],  17, 0x242070db);
+    FF(b, c, d, a, blocks[3],  22, 0xc1bdceee);
+    FF(a, b, c, d, blocks[4],   7, 0xf57c0faf);
+    FF(d, a, b, c, blocks[5],  12, 0x4787c62a);
+    FF(c, d, a, b, blocks[6],  17, 0xa8304613);
+    FF(b, c, d, a, blocks[7],  22, 0xfd469501);
+    FF(a, b, c, d, blocks[8],   7, 0x698098d8);
+    FF(d, a, b, c, blocks[9],  12, 0x8b44f7af);
+    FF(c, d, a, b, blocks[10], 17, 0xffff5bb1);
+    FF(b, c, d, a, blocks[11], 22, 0x895cd7be);
+    FF(a, b, c, d, blocks[12],  7, 0x6b901122);
+    FF(d, a, b, c, blocks[13], 12, 0xfd987193);
+    FF(c, d, a, b, blocks[14], 17, 0xa679438e);
+    FF(b, c, d, a, blocks[15], 22, 0x49b40821);
 
     // Round 2
-    GG(a, b, c, d, blocks_[1],   5, 0xf61e2562);
-    GG(d, a, b, c, blocks_[6],   9, 0xc040b340);
-    GG(c, d, a, b, blocks_[11], 14, 0x265e5a51);
-    GG(b, c, d, a, blocks_[0],  20, 0xe9b6c7aa);
-    GG(a, b, c, d, blocks_[5],   5, 0xd62f105d);
-    GG(d, a, b, c, blocks_[10],  9, 0x02441453);
-    GG(c, d, a, b, blocks_[15], 14, 0xd8a1e681);
-    GG(b, c, d, a, blocks_[4],  20, 0xe7d3fbc8);
-    GG(a, b, c, d, blocks_[9],   5, 0x21e1cde6);
-    GG(d, a, b, c, blocks_[14],  9, 0xc33707d6);
-    GG(c, d, a, b, blocks_[3],  14, 0xf4d50d87);
-    GG(b, c, d, a, blocks_[8],  20, 0x455a14ed);
-    GG(a, b, c, d, blocks_[13],  5, 0xa9e3e905);
-    GG(d, a, b, c, blocks_[2],   9, 0xfcefa3f8);
-    GG(c, d, a, b, blocks_[7],  14, 0x676f02d9);
-    GG(b, c, d, a, blocks_[12], 20, 0x8d2a4c8a);
+    GG(a, b, c, d, blocks[1],   5, 0xf61e2562);
+    GG(d, a, b, c, blocks[6],   9, 0xc040b340);
+    GG(c, d, a, b, blocks[11], 14, 0x265e5a51);
+    GG(b, c, d, a, blocks[0],  20, 0xe9b6c7aa);
+    GG(a, b, c, d, blocks[5],   5, 0xd62f105d);
+    GG(d, a, b, c, blocks[10],  9, 0x02441453);
+    GG(c, d, a, b, blocks[15], 14, 0xd8a1e681);
+    GG(b, c, d, a, blocks[4],  20, 0xe7d3fbc8);
+    GG(a, b, c, d, blocks[9],   5, 0x21e1cde6);
+    GG(d, a, b, c, blocks[14],  9, 0xc33707d6);
+    GG(c, d, a, b, blocks[3],  14, 0xf4d50d87);
+    GG(b, c, d, a, blocks[8],  20, 0x455a14ed);
+    GG(a, b, c, d, blocks[13],  5, 0xa9e3e905);
+    GG(d, a, b, c, blocks[2],   9, 0xfcefa3f8);
+    GG(c, d, a, b, blocks[7],  14, 0x676f02d9);
+    GG(b, c, d, a, blocks[12], 20, 0x8d2a4c8a);
 
     // Round 3
-    HH(a, b, c, d, blocks_[5],   4, 0xfffa3942);
-    HH(d, a, b, c, blocks_[8],  11, 0x8771f681);
-    HH(c, d, a, b, blocks_[11], 16, 0x6d9d6122);
-    HH(b, c, d, a, blocks_[14], 23, 0xfde5380c);
-    HH(a, b, c, d, blocks_[1],   4, 0xa4beea44);
-    HH(d, a, b, c, blocks_[4],  11, 0x4bdecfa9);
-    HH(c, d, a, b, blocks_[7],  16, 0xf6bb4b60);
-    HH(b, c, d, a, blocks_[10], 23, 0xbebfbc70);
-    HH(a, b, c, d, blocks_[13],  4, 0x289b7ec6);
-    HH(d, a, b, c, blocks_[0],  11, 0xeaa127fa);
-    HH(c, d, a, b, blocks_[3],  16, 0xd4ef3085);
-    HH(b, c, d, a, blocks_[6],  23, 0x04881d05);
-    HH(a, b, c, d, blocks_[9],   4, 0xd9d4d039);
-    HH(d, a, b, c, blocks_[12], 11, 0xe6db99e5);
-    HH(c, d, a, b, blocks_[15], 16, 0x1fa27cf8);
-    HH(b, c, d, a, blocks_[2],  23, 0xc4ac5665);
+    HH(a, b, c, d, blocks[5],   4, 0xfffa3942);
+    HH(d, a, b, c, blocks[8],  11, 0x8771f681);
+    HH(c, d, a, b, blocks[11], 16, 0x6d9d6122);
+    HH(b, c, d, a, blocks[14], 23, 0xfde5380c);
+    HH(a, b, c, d, blocks[1],   4, 0xa4beea44);
+    HH(d, a, b, c, blocks[4],  11, 0x4bdecfa9);
+    HH(c, d, a, b, blocks[7],  16, 0xf6bb4b60);
+    HH(b, c, d, a, blocks[10], 23, 0xbebfbc70);
+    HH(a, b, c, d, blocks[13],  4, 0x289b7ec6);
+    HH(d, a, b, c, blocks[0],  11, 0xeaa127fa);
+    HH(c, d, a, b, blocks[3],  16, 0xd4ef3085);
+    HH(b, c, d, a, blocks[6],  23, 0x04881d05);
+    HH(a, b, c, d, blocks[9],   4, 0xd9d4d039);
+    HH(d, a, b, c, blocks[12], 11, 0xe6db99e5);
+    HH(c, d, a, b, blocks[15], 16, 0x1fa27cf8);
+    HH(b, c, d, a, blocks[2],  23, 0xc4ac5665);
 
     // Round 4
-    II(a, b, c, d, blocks_[0],   6, 0xf4292244);
-    II(d, a, b, c, blocks_[7],  10, 0x432aff97);
-    II(c, d, a, b, blocks_[14], 15, 0xab9423a7);
-    II(b, c, d, a, blocks_[5],  21, 0xfc93a039);
-    II(a, b, c, d, blocks_[12],  6, 0x655b59c3);
-    II(d, a, b, c, blocks_[3],  10, 0x8f0ccc92);
-    II(c, d, a, b, blocks_[10], 15, 0xffeff47d);
-    II(b, c, d, a, blocks_[1],  21, 0x85845dd1);
-    II(a, b, c, d, blocks_[8],   6, 0x6fa87e4f);
-    II(d, a, b, c, blocks_[15], 10, 0xfe2ce6e0);
-    II(c, d, a, b, blocks_[6],  15, 0xa3014314);
-    II(b, c, d, a, blocks_[13], 21, 0x4e0811a1);
-    II(a, b, c, d, blocks_[4],   6, 0xf7537e82);
-    II(d, a, b, c, blocks_[11], 10, 0xbd3af235);
-    II(c, d, a, b, blocks_[2],  15, 0x2ad7d2bb);
-    II(b, c, d, a, blocks_[9],  21, 0xeb86d391);
+    II(a, b, c, d, blocks[0],   6, 0xf4292244);
+    II(d, a, b, c, blocks[7],  10, 0x432aff97);
+    II(c, d, a, b, blocks[14], 15, 0xab9423a7);
+    II(b, c, d, a, blocks[5],  21, 0xfc93a039);
+    II(a, b, c, d, blocks[12],  6, 0x655b59c3);
+    II(d, a, b, c, blocks[3],  10, 0x8f0ccc92);
+    II(c, d, a, b, blocks[10], 15, 0xffeff47d);
+    II(b, c, d, a, blocks[1],  21, 0x85845dd1);
+    II(a, b, c, d, blocks[8],   6, 0x6fa87e4f);
+    II(d, a, b, c, blocks[15], 10, 0xfe2ce6e0);
+    II(c, d, a, b, blocks[6],  15, 0xa3014314);
+    II(b, c, d, a, blocks[13], 21, 0x4e0811a1);
+    II(a, b, c, d, blocks[4],   6, 0xf7537e82);
+    II(d, a, b, c, blocks[11], 10, 0xbd3af235);
+    II(c, d, a, b, blocks[2],  15, 0x2ad7d2bb);
+    II(b, c, d, a, blocks[9],  21, 0xeb86d391);
 
-    a0_ += a;
-    b0_ += b;
-    c0_ += c;
-    d0_ += d;
+    intermediate_hash_[0] += a;
+    intermediate_hash_[1] += b;
+    intermediate_hash_[2] += c;
+    intermediate_hash_[3] += d;
+
+    buffer_index_ = 0U;
+}
+
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::get_digest() noexcept -> return_type
+{
+    return_type digest {};
+    if (corrupted)
+    {
+        return digest;
+    }
+
+    auto used {(low_ >> 3U) & 0x3F}; // Number of bytes used in buffer
+    buffer_[used++] = 0x80;
+    auto available {buffer_.size() - used};
+
+    if (available < 8U)
+    {
+        fill_array(buffer_.begin() + used, buffer_.end(), static_cast<boost::crypt::uint8_t>(0));
+        process_message_block();
+        used = 0;
+        buffer_.fill(0);
+    }
+    else
+    {
+        fill_array(buffer_.begin() + used, buffer_.end() - 8, static_cast<boost::crypt::uint8_t>(0));
+    }
+
+    const auto total_bits {(static_cast<uint64_t>(high_) << 32) | low_};
+
+    // Append the length in bits as a 64-bit little-endian integer
+    buffer_[56] = static_cast<boost::crypt::uint8_t>(total_bits & 0xFF);
+    buffer_[57] = static_cast<boost::crypt::uint8_t>((total_bits >> 8) & 0xFF);
+    buffer_[58] = static_cast<boost::crypt::uint8_t>((total_bits >> 16) & 0xFF);
+    buffer_[59] = static_cast<boost::crypt::uint8_t>((total_bits >> 24) & 0xFF);
+    buffer_[60] = static_cast<boost::crypt::uint8_t>((total_bits >> 32) & 0xFF);
+    buffer_[61] = static_cast<boost::crypt::uint8_t>((total_bits >> 40) & 0xFF);
+    buffer_[62] = static_cast<boost::crypt::uint8_t>((total_bits >> 48) & 0xFF);
+    buffer_[63] = static_cast<boost::crypt::uint8_t>((total_bits >> 56) & 0xFF);
+
+    process_message_block();
+    computed = true;
+
+    for (boost::crypt::size_t i {}; i < intermediate_hash_.size(); ++i)
+    {
+        digest[i*4]     = static_cast<boost::crypt::uint8_t>(intermediate_hash_[i] & 0xFF);
+        digest[i*4 + 1] = static_cast<boost::crypt::uint8_t>((intermediate_hash_[i] >> 8U) & 0xFF);
+        digest[i*4 + 2] = static_cast<boost::crypt::uint8_t>((intermediate_hash_[i] >> 16U) & 0xFF);
+        digest[i*4 + 3] = static_cast<boost::crypt::uint8_t>((intermediate_hash_[i] >> 24U) & 0xFF);
+    }
+
+    return digest;
 }
 
 namespace detail {

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -48,37 +48,39 @@ private:
     bool corrupted {};
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto md5_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto md5_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto md5_convert_buffer_to_blocks() noexcept;
+    BOOST_CRYPT_GPU_ENABLED inline auto md5_convert_buffer_to_blocks() noexcept;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto md5_copy_data(ForwardIter data, boost::crypt::size_t offset, boost::crypt::size_t size) noexcept;
+    BOOST_CRYPT_GPU_ENABLED inline auto md5_copy_data(ForwardIter data, boost::crypt::size_t offset, boost::crypt::size_t size) noexcept;
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto md5_body() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED inline auto md5_body() noexcept -> void;
 
 public:
 
     using return_type = boost::crypt::array<boost::crypt::uint8_t, 16>;
-    
-    BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void;
+
+    BOOST_CRYPT_GPU_ENABLED inline md5_hasher() noexcept { this-> init(); }
+
+    BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type;
+    BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
 };
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::init() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::init() noexcept -> void
 {
     a0_ = 0x67452301U;
     b0_ = 0xefcdab89U;
@@ -95,7 +97,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::init() noexcept -> void
     corrupted = false;
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_convert_buffer_to_blocks() noexcept
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_convert_buffer_to_blocks() noexcept
 {
     boost::crypt::size_t buffer_index {};
     for (auto& block : blocks_)
@@ -112,7 +114,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_convert_buffer_to_blocks(
 }
 
 template <typename ForwardIter>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_copy_data(ForwardIter data, boost::crypt::size_t offset, boost::crypt::size_t size) noexcept
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_copy_data(ForwardIter data, boost::crypt::size_t offset, boost::crypt::size_t size) noexcept
 {
     for (boost::crypt::size_t i {}; i < size; ++i)
     {
@@ -122,7 +124,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_copy_data(ForwardIter dat
 }
 
 template <typename ForwardIter>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
 {
     if (size == 0U)
     {
@@ -189,7 +191,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_update(ForwardIter data, 
     return hasher_state::success;
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::get_digest() noexcept -> return_type
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::get_digest() noexcept -> return_type
 {
     return_type digest {};
     if (corrupted)
@@ -243,7 +245,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::get_digest() noexcept -> retu
 }
 
 template <typename ByteType>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_byte(ByteType byte) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_byte(ByteType byte) noexcept -> hasher_state
 {
     static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
     const auto value {static_cast<boost::crypt::uint8_t>(byte)};
@@ -251,7 +253,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_byte(ByteType byte) n
 }
 
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     if (!utility::is_null(buffer))
     {
@@ -264,7 +266,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_bytes(ForwardIter buf
 }
 
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -295,7 +297,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_bytes(ForwardIter buf
 }
 
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -329,48 +331,48 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_bytes(ForwardIter buf
 // Section 18.5
 namespace md5_body_detail {
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto F(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED inline auto F(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return (x & y) | ((~x) & z);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto G(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED inline auto G(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return (x & z) | (y & (~z));
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto H(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED inline auto H(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return x ^ y ^ z;
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto I(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED inline auto I(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return y ^ (x | (~z));
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto FF(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED inline auto FF(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                           boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                           boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + F(b, c, d) + Mj + ti), si);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto GG(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED inline auto GG(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                           boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                           boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + G(b, c, d) + Mj + ti), si);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto HH(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED inline auto HH(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                           boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                           boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + H(b, c, d) + Mj + ti), si);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto II(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED inline auto II(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                           boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                           boost::crypt::uint32_t ti) noexcept
 {
@@ -379,7 +381,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto II(boost::crypt::uint32_t& a, boost::cryp
 
 } // md5_body_detail
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_body() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::md5_body() noexcept -> void
 {
     using namespace md5_body_detail;
 
@@ -469,7 +471,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::md5_body() noexcept -> void
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(T begin, T end) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto md5(T begin, T end) noexcept -> md5_hasher::return_type
 {
     if (end < begin)
     {
@@ -491,7 +493,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto md5(T begin, T end) noexcept -> md5_hashe
 
 } // Namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -502,7 +504,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str) n
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -512,7 +514,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str, b
     return detail::md5(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const boost::crypt::uint8_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const boost::crypt::uint8_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -523,7 +525,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const boost::crypt
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -533,7 +535,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const boost::crypt
     return detail::md5(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -544,7 +546,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* st
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -554,7 +556,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* st
     return detail::md5(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -565,7 +567,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* st
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -577,7 +579,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* st
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -588,7 +590,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -721,7 +723,7 @@ BOOST_CRYPT_EXPORT inline auto md5_file(std::string_view filepath) noexcept -> m
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-constexpr auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_type
+inline auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_type
 {
     return detail::md5(data.begin(), data.end());
 }
@@ -731,7 +733,7 @@ constexpr auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_typ
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
 {
     return detail::md5(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -31,7 +31,7 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class md5_hasher : public hash_detail::hasher_base_512<16U, 4U>
+BOOST_CRYPT_EXPORT class md5_hasher final : public hash_detail::hasher_base_512<16U, 4U>
 {
 public:
 

--- a/include/boost/crypt/hash/sha1.hpp
+++ b/include/boost/crypt/hash/sha1.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_CRYPT_HASH_SHA1_HPP
 #define BOOST_CRYPT_HASH_SHA1_HPP
 
+#include <boost/crypt/hash/detail/hasher_base_512.hpp>
 #include <boost/crypt/hash/hasher_state.hpp>
 #include <boost/crypt/utility/config.hpp>
 #include <boost/crypt/utility/bit.hpp>
@@ -30,58 +31,38 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class sha1_hasher
+BOOST_CRYPT_EXPORT class sha1_hasher final : public hash_detail::hasher_base_512<20U, 5U>
 {
 public:
 
-    using return_type = boost::crypt::array<boost::crypt::uint8_t, 20>;
+    BOOST_CRYPT_GPU_ENABLED sha1_hasher() noexcept { this->init(); }
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto init() -> void;
-
-    template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-
-    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type ;
+    BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
 
 private:
 
-    boost::crypt::array<boost::crypt::uint32_t, 5> intermediate_hash_ { 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 };
-    boost::crypt::array<boost::crypt::uint8_t, 64> buffer_ {};
-
-    boost::crypt::size_t buffer_index_ {};
-    boost::crypt::size_t low_ {};
-    boost::crypt::size_t high_ {};
-
-    bool computed {};
-    bool corrupted {};
-
-    BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_process_message_block() -> void;
-
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
-
-    BOOST_CRYPT_GPU_ENABLED constexpr auto pad_message() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void override;
 };
 
-namespace detail {
+BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::init() noexcept -> void
+{
+    hash_detail::hasher_base_512<20U, 5U>::base_init();
 
-BOOST_CRYPT_GPU_ENABLED
-constexpr auto round1(boost::crypt::uint32_t& A,
-                      boost::crypt::uint32_t& B,
-                      boost::crypt::uint32_t& C,
-                      boost::crypt::uint32_t& D,
-                      boost::crypt::uint32_t& E,
-                      boost::crypt::uint32_t  W)
+    intermediate_hash_[0] = 0x67452301;
+    intermediate_hash_[1] = 0xEFCDAB89;
+    intermediate_hash_[2] = 0x98BADCFE;
+    intermediate_hash_[3] = 0x10325476;
+    intermediate_hash_[4] = 0xC3D2E1F0;
+}
+
+namespace sha1_detail {
+
+BOOST_CRYPT_GPU_ENABLED inline auto round1(boost::crypt::uint32_t& A,
+                                           boost::crypt::uint32_t& B,
+                                           boost::crypt::uint32_t& C,
+                                           boost::crypt::uint32_t& D,
+                                           boost::crypt::uint32_t& E,
+                                           boost::crypt::uint32_t  W)
 {
     const auto temp {detail::rotl(A, 5U) + ((B & C) | ((~B) & D)) + E + W + 0x5A827999U};
     E = D;
@@ -91,13 +72,12 @@ constexpr auto round1(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-BOOST_CRYPT_GPU_ENABLED
-constexpr auto round2(boost::crypt::uint32_t& A,
-                      boost::crypt::uint32_t& B,
-                      boost::crypt::uint32_t& C,
-                      boost::crypt::uint32_t& D,
-                      boost::crypt::uint32_t& E,
-                      boost::crypt::uint32_t  W)
+BOOST_CRYPT_GPU_ENABLED inline auto round2(boost::crypt::uint32_t& A,
+                                           boost::crypt::uint32_t& B,
+                                           boost::crypt::uint32_t& C,
+                                           boost::crypt::uint32_t& D,
+                                           boost::crypt::uint32_t& E,
+                                           boost::crypt::uint32_t  W)
 {
     const auto temp {detail::rotl(A, 5U) + (B ^ C ^ D) + E + W + 0x6ED9EBA1U};
     E = D;
@@ -107,13 +87,12 @@ constexpr auto round2(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-BOOST_CRYPT_GPU_ENABLED
-constexpr auto round3(boost::crypt::uint32_t& A,
-                      boost::crypt::uint32_t& B,
-                      boost::crypt::uint32_t& C,
-                      boost::crypt::uint32_t& D,
-                      boost::crypt::uint32_t& E,
-                      boost::crypt::uint32_t  W)
+BOOST_CRYPT_GPU_ENABLED inline auto round3(boost::crypt::uint32_t& A,
+                                           boost::crypt::uint32_t& B,
+                                           boost::crypt::uint32_t& C,
+                                           boost::crypt::uint32_t& D,
+                                           boost::crypt::uint32_t& E,
+                                           boost::crypt::uint32_t  W)
 {
     const auto temp {detail::rotl(A, 5U) + ((B & C) | (B & D) | (C & D)) + E + W + 0x8F1BBCDCU};
     E = D;
@@ -123,13 +102,12 @@ constexpr auto round3(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-BOOST_CRYPT_GPU_ENABLED
-constexpr auto round4(boost::crypt::uint32_t& A,
-                      boost::crypt::uint32_t& B,
-                      boost::crypt::uint32_t& C,
-                      boost::crypt::uint32_t& D,
-                      boost::crypt::uint32_t& E,
-                      boost::crypt::uint32_t  W)
+BOOST_CRYPT_GPU_ENABLED inline auto round4(boost::crypt::uint32_t& A,
+                                           boost::crypt::uint32_t& B,
+                                           boost::crypt::uint32_t& C,
+                                           boost::crypt::uint32_t& D,
+                                           boost::crypt::uint32_t& E,
+                                           boost::crypt::uint32_t  W)
 {
     const auto temp {detail::rotl(A, 5U) + (B ^ C ^ D) + E + W + 0xCA62C1D6U};
     E = D;
@@ -139,11 +117,13 @@ constexpr auto round4(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-} // Namespace detail
+} // Namespace sha1_detail
 
 // See definitions from the RFC on the rounds
-constexpr auto sha1_hasher::sha1_process_message_block() -> void
+BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::process_message_block() noexcept -> void
 {
+    using namespace sha1_detail;
+
     boost::crypt::array<boost::crypt::uint32_t, 80> W {};
 
     // Init the first 16 words of W
@@ -168,92 +148,92 @@ constexpr auto sha1_hasher::sha1_process_message_block() -> void
     auto E {intermediate_hash_[4]};
 
     // Round 1
-    detail::round1(A, B, C, D, E, W[0]);
-    detail::round1(A, B, C, D, E, W[1]);
-    detail::round1(A, B, C, D, E, W[2]);
-    detail::round1(A, B, C, D, E, W[3]);
-    detail::round1(A, B, C, D, E, W[4]);
-    detail::round1(A, B, C, D, E, W[5]);
-    detail::round1(A, B, C, D, E, W[6]);
-    detail::round1(A, B, C, D, E, W[7]);
-    detail::round1(A, B, C, D, E, W[8]);
-    detail::round1(A, B, C, D, E, W[9]);
-    detail::round1(A, B, C, D, E, W[10]);
-    detail::round1(A, B, C, D, E, W[11]);
-    detail::round1(A, B, C, D, E, W[12]);
-    detail::round1(A, B, C, D, E, W[13]);
-    detail::round1(A, B, C, D, E, W[14]);
-    detail::round1(A, B, C, D, E, W[15]);
-    detail::round1(A, B, C, D, E, W[16]);
-    detail::round1(A, B, C, D, E, W[17]);
-    detail::round1(A, B, C, D, E, W[18]);
-    detail::round1(A, B, C, D, E, W[19]);
+    round1(A, B, C, D, E, W[0]);
+    round1(A, B, C, D, E, W[1]);
+    round1(A, B, C, D, E, W[2]);
+    round1(A, B, C, D, E, W[3]);
+    round1(A, B, C, D, E, W[4]);
+    round1(A, B, C, D, E, W[5]);
+    round1(A, B, C, D, E, W[6]);
+    round1(A, B, C, D, E, W[7]);
+    round1(A, B, C, D, E, W[8]);
+    round1(A, B, C, D, E, W[9]);
+    round1(A, B, C, D, E, W[10]);
+    round1(A, B, C, D, E, W[11]);
+    round1(A, B, C, D, E, W[12]);
+    round1(A, B, C, D, E, W[13]);
+    round1(A, B, C, D, E, W[14]);
+    round1(A, B, C, D, E, W[15]);
+    round1(A, B, C, D, E, W[16]);
+    round1(A, B, C, D, E, W[17]);
+    round1(A, B, C, D, E, W[18]);
+    round1(A, B, C, D, E, W[19]);
 
     // Round 2
-    detail::round2(A, B, C, D, E, W[20]);
-    detail::round2(A, B, C, D, E, W[21]);
-    detail::round2(A, B, C, D, E, W[22]);
-    detail::round2(A, B, C, D, E, W[23]);
-    detail::round2(A, B, C, D, E, W[24]);
-    detail::round2(A, B, C, D, E, W[25]);
-    detail::round2(A, B, C, D, E, W[26]);
-    detail::round2(A, B, C, D, E, W[27]);
-    detail::round2(A, B, C, D, E, W[28]);
-    detail::round2(A, B, C, D, E, W[29]);
-    detail::round2(A, B, C, D, E, W[30]);
-    detail::round2(A, B, C, D, E, W[31]);
-    detail::round2(A, B, C, D, E, W[32]);
-    detail::round2(A, B, C, D, E, W[33]);
-    detail::round2(A, B, C, D, E, W[34]);
-    detail::round2(A, B, C, D, E, W[35]);
-    detail::round2(A, B, C, D, E, W[36]);
-    detail::round2(A, B, C, D, E, W[37]);
-    detail::round2(A, B, C, D, E, W[38]);
-    detail::round2(A, B, C, D, E, W[39]);
+    round2(A, B, C, D, E, W[20]);
+    round2(A, B, C, D, E, W[21]);
+    round2(A, B, C, D, E, W[22]);
+    round2(A, B, C, D, E, W[23]);
+    round2(A, B, C, D, E, W[24]);
+    round2(A, B, C, D, E, W[25]);
+    round2(A, B, C, D, E, W[26]);
+    round2(A, B, C, D, E, W[27]);
+    round2(A, B, C, D, E, W[28]);
+    round2(A, B, C, D, E, W[29]);
+    round2(A, B, C, D, E, W[30]);
+    round2(A, B, C, D, E, W[31]);
+    round2(A, B, C, D, E, W[32]);
+    round2(A, B, C, D, E, W[33]);
+    round2(A, B, C, D, E, W[34]);
+    round2(A, B, C, D, E, W[35]);
+    round2(A, B, C, D, E, W[36]);
+    round2(A, B, C, D, E, W[37]);
+    round2(A, B, C, D, E, W[38]);
+    round2(A, B, C, D, E, W[39]);
 
     // Round 3
-    detail::round3(A, B, C, D, E, W[40]);
-    detail::round3(A, B, C, D, E, W[41]);
-    detail::round3(A, B, C, D, E, W[42]);
-    detail::round3(A, B, C, D, E, W[43]);
-    detail::round3(A, B, C, D, E, W[44]);
-    detail::round3(A, B, C, D, E, W[45]);
-    detail::round3(A, B, C, D, E, W[46]);
-    detail::round3(A, B, C, D, E, W[47]);
-    detail::round3(A, B, C, D, E, W[48]);
-    detail::round3(A, B, C, D, E, W[49]);
-    detail::round3(A, B, C, D, E, W[50]);
-    detail::round3(A, B, C, D, E, W[51]);
-    detail::round3(A, B, C, D, E, W[52]);
-    detail::round3(A, B, C, D, E, W[53]);
-    detail::round3(A, B, C, D, E, W[54]);
-    detail::round3(A, B, C, D, E, W[55]);
-    detail::round3(A, B, C, D, E, W[56]);
-    detail::round3(A, B, C, D, E, W[57]);
-    detail::round3(A, B, C, D, E, W[58]);
-    detail::round3(A, B, C, D, E, W[59]);
+    round3(A, B, C, D, E, W[40]);
+    round3(A, B, C, D, E, W[41]);
+    round3(A, B, C, D, E, W[42]);
+    round3(A, B, C, D, E, W[43]);
+    round3(A, B, C, D, E, W[44]);
+    round3(A, B, C, D, E, W[45]);
+    round3(A, B, C, D, E, W[46]);
+    round3(A, B, C, D, E, W[47]);
+    round3(A, B, C, D, E, W[48]);
+    round3(A, B, C, D, E, W[49]);
+    round3(A, B, C, D, E, W[50]);
+    round3(A, B, C, D, E, W[51]);
+    round3(A, B, C, D, E, W[52]);
+    round3(A, B, C, D, E, W[53]);
+    round3(A, B, C, D, E, W[54]);
+    round3(A, B, C, D, E, W[55]);
+    round3(A, B, C, D, E, W[56]);
+    round3(A, B, C, D, E, W[57]);
+    round3(A, B, C, D, E, W[58]);
+    round3(A, B, C, D, E, W[59]);
 
     // Round 4
-    detail::round4(A, B, C, D, E, W[60]);
-    detail::round4(A, B, C, D, E, W[61]);
-    detail::round4(A, B, C, D, E, W[62]);
-    detail::round4(A, B, C, D, E, W[63]);
-    detail::round4(A, B, C, D, E, W[64]);
-    detail::round4(A, B, C, D, E, W[65]);
-    detail::round4(A, B, C, D, E, W[66]);
-    detail::round4(A, B, C, D, E, W[67]);
-    detail::round4(A, B, C, D, E, W[68]);
-    detail::round4(A, B, C, D, E, W[69]);
-    detail::round4(A, B, C, D, E, W[70]);
-    detail::round4(A, B, C, D, E, W[71]);
-    detail::round4(A, B, C, D, E, W[72]);
-    detail::round4(A, B, C, D, E, W[73]);
-    detail::round4(A, B, C, D, E, W[74]);
-    detail::round4(A, B, C, D, E, W[75]);
-    detail::round4(A, B, C, D, E, W[76]);
-    detail::round4(A, B, C, D, E, W[77]);
-    detail::round4(A, B, C, D, E, W[78]);
-    detail::round4(A, B, C, D, E, W[79]);
+    round4(A, B, C, D, E, W[60]);
+    round4(A, B, C, D, E, W[61]);
+    round4(A, B, C, D, E, W[62]);
+    round4(A, B, C, D, E, W[63]);
+    round4(A, B, C, D, E, W[64]);
+    round4(A, B, C, D, E, W[65]);
+    round4(A, B, C, D, E, W[66]);
+    round4(A, B, C, D, E, W[67]);
+    round4(A, B, C, D, E, W[68]);
+    round4(A, B, C, D, E, W[69]);
+    round4(A, B, C, D, E, W[70]);
+    round4(A, B, C, D, E, W[71]);
+    round4(A, B, C, D, E, W[72]);
+    round4(A, B, C, D, E, W[73]);
+    round4(A, B, C, D, E, W[74]);
+    round4(A, B, C, D, E, W[75]);
+    round4(A, B, C, D, E, W[76]);
+    round4(A, B, C, D, E, W[77]);
+    round4(A, B, C, D, E, W[78]);
+    round4(A, B, C, D, E, W[79]);
 
     intermediate_hash_[0] += A;
     intermediate_hash_[1] += B;
@@ -264,231 +244,10 @@ constexpr auto sha1_hasher::sha1_process_message_block() -> void
     buffer_index_ = 0U;
 }
 
-// Like MD5, the message must be padded to an even 512 bits.
-// The first bit of padding must be a 1
-// The last 64-bits should be the length of the message
-// All bits in between should be 0s
-constexpr auto sha1_hasher::pad_message() noexcept -> void
-{
-    constexpr boost::crypt::size_t message_length_start_index {56U};
-
-    // We don't have enough space for everything we need
-    if (buffer_index_ >= message_length_start_index)
-    {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x80);
-        while (buffer_index_ < buffer_.size())
-        {
-            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
-        }
-
-        sha1_process_message_block();
-
-        while (buffer_index_ < message_length_start_index)
-        {
-            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
-        }
-    }
-    else
-    {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x80);
-        while (buffer_index_ < message_length_start_index)
-        {
-            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
-        }
-    }
-
-    // Add the message length to the end of the buffer
-    BOOST_CRYPT_ASSERT(buffer_index_ == message_length_start_index);
-
-    buffer_[56U] = static_cast<boost::crypt::uint8_t>(high_ >> 24U);
-    buffer_[57U] = static_cast<boost::crypt::uint8_t>(high_ >> 16U);
-    buffer_[58U] = static_cast<boost::crypt::uint8_t>(high_ >>  8U);
-    buffer_[59U] = static_cast<boost::crypt::uint8_t>(high_);
-    buffer_[60U] = static_cast<boost::crypt::uint8_t>(low_ >> 24U);
-    buffer_[61U] = static_cast<boost::crypt::uint8_t>(low_ >> 16U);
-    buffer_[62U] = static_cast<boost::crypt::uint8_t>(low_ >>  8U);
-    buffer_[63U] = static_cast<boost::crypt::uint8_t>(low_);
-
-    sha1_process_message_block();
-}
-
-template <typename ForwardIter>
-constexpr auto sha1_hasher::sha1_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
-{
-    if (size == 0U)
-    {
-        return hasher_state::success;
-    }
-    if (computed)
-    {
-        corrupted = true;
-    }
-    if (corrupted)
-    {
-        return hasher_state::state_error;
-    }
-
-    while (size-- && !corrupted)
-    {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(static_cast<boost::crypt::uint8_t>(*data) &
-                                                                      static_cast<boost::crypt::uint8_t>(0xFF));
-        low_ += 8U;
-
-        if (BOOST_CRYPT_UNLIKELY(low_ == 0))
-        {
-            // Would indicate size_t rollover which should not happen on a single data stream
-            // LCOV_EXCL_START
-            ++high_;
-            if (high_ == 0)
-            {
-                corrupted = true;
-                return hasher_state::input_too_long;
-            }
-            // LCOV_EXCL_STOP
-        }
-
-        if (buffer_index_ == buffer_.size())
-        {
-            sha1_process_message_block();
-        }
-
-        ++data;
-    }
-
-    return hasher_state::success;
-}
-
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::init() -> void
-{
-    intermediate_hash_[0] = 0x67452301;
-    intermediate_hash_[1] = 0xEFCDAB89;
-    intermediate_hash_[2] = 0x98BADCFE;
-    intermediate_hash_[3] = 0x10325476;
-    intermediate_hash_[4] = 0xC3D2E1F0;
-
-    buffer_.fill(0);
-    buffer_index_ = 0UL;
-    low_ = 0UL;
-    high_ = 0UL;
-    computed = false;
-    corrupted = false;
-}
-
-template <typename ByteType>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::process_byte(ByteType byte) noexcept -> hasher_state
-{
-    static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
-    const auto value {static_cast<boost::crypt::uint8_t>(byte)};
-    return sha1_update(&value, 1UL);
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    if (!utility::is_null(buffer))
-    {
-        return sha1_update(buffer, byte_count);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    #ifndef BOOST_CRYPT_HAS_CUDA
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* char_ptr {reinterpret_cast<const char *>(std::addressof(*buffer))};
-        const auto* data {reinterpret_cast<const unsigned char *>(char_ptr)};
-        return sha1_update(data, byte_count * 2U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #else
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
-        return sha1_update(data, byte_count * 2U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #endif
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    #ifndef BOOST_CRYPT_HAS_CUDA
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* char_ptr {reinterpret_cast<const char *>(std::addressof(*buffer))};
-        const auto* data {reinterpret_cast<const unsigned char *>(char_ptr)};
-        return sha1_update(data, byte_count * 4U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #else
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
-        return sha1_update(data, byte_count * 4U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #endif
-}
-
-constexpr auto sha1_hasher::get_digest() noexcept -> sha1_hasher::return_type
-{
-    boost::crypt::array<boost::crypt::uint8_t, 20> digest{};
-
-    if (corrupted)
-    {
-        // Return empty message on corruption
-        return digest;
-    }
-    if (!computed)
-    {
-        pad_message();
-
-        // Overwrite whatever is in the buffer in case it is sensitive
-        buffer_.fill(0);
-        low_ = 0U;
-        high_ = 0U;
-        computed = true;
-    }
-
-    for (boost::crypt::size_t i {}; i < digest.size(); ++i)
-    {
-        digest[i] = static_cast<boost::crypt::uint8_t>(intermediate_hash_[i >> 2U] >> 8 * (3 - (i & 0x03)));
-    }
-
-    return digest;
-}
-
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(T begin, T end) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(T begin, T end) noexcept -> sha1_hasher::return_type
 {
     if (end < begin)
     {
@@ -511,7 +270,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(T begin, T end) noexcept -> sha1_has
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -522,7 +281,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str) 
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -532,7 +291,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str, 
     return detail::sha1(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const boost::crypt::uint8_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const boost::crypt::uint8_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -543,7 +302,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const boost::cryp
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -553,7 +312,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const boost::cryp
     return detail::sha1(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -564,7 +323,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* s
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -574,7 +333,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* s
     return detail::sha1(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -585,7 +344,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* s
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -597,7 +356,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* s
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -608,7 +367,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* st
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -741,7 +500,7 @@ BOOST_CRYPT_EXPORT inline auto sha1_file(std::string_view filepath) noexcept -> 
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-constexpr auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+inline auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_type
 {
     return detail::sha1(data.begin(), data.end());
 }
@@ -751,7 +510,7 @@ constexpr auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_t
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
 {
     return detail::sha1(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha1.hpp
+++ b/include/boost/crypt/hash/sha1.hpp
@@ -41,7 +41,7 @@ public:
 
 private:
 
-    BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void override;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void override;
 };
 
 BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::init() noexcept -> void

--- a/include/boost/crypt/hash/sha256.hpp
+++ b/include/boost/crypt/hash/sha256.hpp
@@ -41,7 +41,7 @@ public:
 
 private:
 
-    BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void override;
+    BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void override;
 };
 
 BOOST_CRYPT_GPU_ENABLED inline auto sha256_hasher::init() noexcept -> void

--- a/include/boost/crypt/hash/sha256.hpp
+++ b/include/boost/crypt/hash/sha256.hpp
@@ -31,7 +31,7 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class sha256_hasher : public hash_detail::hasher_base_512<32U, 8U>
+BOOST_CRYPT_EXPORT class sha256_hasher final : public hash_detail::hasher_base_512<32U, 8U>
 {
 public:
 

--- a/include/boost/crypt/hash/sha256.hpp
+++ b/include/boost/crypt/hash/sha256.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_CRYPT_HASH_SHA256_HPP
 #define BOOST_CRYPT_HASH_SHA256_HPP
 
+#include <boost/crypt/hash/detail/hasher_base_512.hpp>
 #include <boost/crypt/hash/hasher_state.hpp>
 #include <boost/crypt/utility/config.hpp>
 #include <boost/crypt/utility/bit.hpp>
@@ -30,49 +31,33 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class sha256_hasher
+BOOST_CRYPT_EXPORT class sha256_hasher : public hash_detail::hasher_base_512<32U, 8U>
 {
 public:
 
-    using return_type = boost::crypt::array<boost::crypt::uint8_t, 32>;
+    BOOST_CRYPT_GPU_ENABLED sha256_hasher() { this->init(); }
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto init() -> void;
-
-    template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-    template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
-
-
-    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type ;
+    BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
 
 private:
 
-    boost::crypt::array<boost::crypt::uint32_t, 8> intermediate_hash_ { 0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
-                                                                        0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19 };
-    boost::crypt::array<boost::crypt::uint8_t, 64> buffer_ {};
-
-    boost::crypt::size_t buffer_index_ {};
-    boost::crypt::size_t low_ {};
-    boost::crypt::size_t high_ {};
-
-    bool computed {};
-    bool corrupted {};
-
-    BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_process_message_block() -> void;
-
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
-
-    BOOST_CRYPT_GPU_ENABLED constexpr auto pad_message() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED auto process_message_block() noexcept -> void override;
 };
+
+BOOST_CRYPT_GPU_ENABLED inline auto sha256_hasher::init() noexcept -> void
+{
+    hash_detail::hasher_base_512<32U, 8U>::base_init();
+
+    // https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+    intermediate_hash_[0] = 0x6A09E667;
+    intermediate_hash_[1] = 0xBB67AE85;
+    intermediate_hash_[2] = 0x3C6EF372;
+    intermediate_hash_[3] = 0xA54FF53A;
+    intermediate_hash_[4] = 0x510E527F;
+    intermediate_hash_[5] = 0x9B05688C;
+    intermediate_hash_[6] = 0x1F83D9AB;
+    intermediate_hash_[7] = 0x5BE0CD19;
+}
 
 namespace sha256_detail {
 
@@ -96,32 +81,32 @@ BOOST_CRYPT_INLINE_CONSTEXPR boost::crypt::array<boost::crypt::uint32_t, 64> sha
 
 // https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 // See section 4.1.2
-BOOST_CRYPT_GPU_ENABLED constexpr auto big_sigma0(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
+BOOST_CRYPT_GPU_ENABLED inline auto big_sigma0(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
 {
     return detail::rotr(value, 2U) ^ detail::rotr(value, 13U) ^ detail::rotr(value, 22U);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto big_sigma1(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
+BOOST_CRYPT_GPU_ENABLED inline auto big_sigma1(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
 {
     return detail::rotr(value, 6U) ^ detail::rotr(value, 11U) ^ detail::rotr(value, 25U);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto little_sigma0(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
+BOOST_CRYPT_GPU_ENABLED inline auto little_sigma0(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
 {
     return detail::rotr(value, 7U) ^ detail::rotr(value, 18U) ^ (value >> 3U);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto little_sigma1(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
+BOOST_CRYPT_GPU_ENABLED inline auto little_sigma1(const boost::crypt::uint32_t value) noexcept -> boost::crypt::uint32_t
 {
     return detail::rotr(value, 17U) ^ detail::rotr(value, 19U) ^ (value >> 10U);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha_ch(const boost::crypt::uint32_t x, const boost::crypt::uint32_t y, const boost::crypt::uint32_t z) noexcept -> boost::crypt::uint32_t
+BOOST_CRYPT_GPU_ENABLED inline auto sha_ch(const boost::crypt::uint32_t x, const boost::crypt::uint32_t y, const boost::crypt::uint32_t z) noexcept -> boost::crypt::uint32_t
 {
     return (x & y) ^ ((~x) & z);
 }
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha_maj(const boost::crypt::uint32_t x, const boost::crypt::uint32_t y, const boost::crypt::uint32_t z) noexcept -> boost::crypt::uint32_t
+BOOST_CRYPT_GPU_ENABLED inline auto sha_maj(const boost::crypt::uint32_t x, const boost::crypt::uint32_t y, const boost::crypt::uint32_t z) noexcept -> boost::crypt::uint32_t
 {
     return (x & y) ^ (x & z) ^ (y & z);
 }
@@ -129,9 +114,9 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto sha_maj(const boost::crypt::uint32_t x, c
 } // Namespace sha256_detail
 
 // See definitions from the RFC on the rounds
-constexpr auto sha256_hasher::sha256_process_message_block() -> void
+BOOST_CRYPT_GPU_ENABLED inline auto sha256_hasher::process_message_block() noexcept -> void
 {
-    // On host we prefer this array to be static but,
+    // On the host we prefer this array to be static but,
     // in a CUDA environment it solves linking problems to move into the function
 
     #ifdef BOOST_CRYPT_HAS_CUDA
@@ -207,235 +192,10 @@ constexpr auto sha256_hasher::sha256_process_message_block() -> void
     buffer_index_ = 0U;
 }
 
-// Like MD5, the message must be padded to an even 512 bits.
-// The first bit of padding must be a 1
-// The last 64-bits should be the length of the message
-// All bits in between should be 0s
-constexpr auto sha256_hasher::pad_message() noexcept -> void
-{
-    constexpr boost::crypt::size_t message_length_start_index {56U};
-
-    // We don't have enough space for everything we need
-    if (buffer_index_ >= message_length_start_index)
-    {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x80);
-        while (buffer_index_ < buffer_.size())
-        {
-            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
-        }
-
-        sha256_process_message_block();
-
-        while (buffer_index_ < message_length_start_index)
-        {
-            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
-        }
-    }
-    else
-    {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x80);
-        while (buffer_index_ < message_length_start_index)
-        {
-            buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(0x00);
-        }
-    }
-
-    // Add the message length to the end of the buffer
-    BOOST_CRYPT_ASSERT(buffer_index_ == message_length_start_index);
-
-    buffer_[56U] = static_cast<boost::crypt::uint8_t>(high_ >> 24U);
-    buffer_[57U] = static_cast<boost::crypt::uint8_t>(high_ >> 16U);
-    buffer_[58U] = static_cast<boost::crypt::uint8_t>(high_ >>  8U);
-    buffer_[59U] = static_cast<boost::crypt::uint8_t>(high_);
-    buffer_[60U] = static_cast<boost::crypt::uint8_t>(low_ >> 24U);
-    buffer_[61U] = static_cast<boost::crypt::uint8_t>(low_ >> 16U);
-    buffer_[62U] = static_cast<boost::crypt::uint8_t>(low_ >>  8U);
-    buffer_[63U] = static_cast<boost::crypt::uint8_t>(low_);
-
-    sha256_process_message_block();
-}
-
-template <typename ForwardIter>
-constexpr auto sha256_hasher::sha256_update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
-{
-    if (size == 0U)
-    {
-        return hasher_state::success;
-    }
-    if (computed)
-    {
-        corrupted = true;
-    }
-    if (corrupted)
-    {
-        return hasher_state::state_error;
-    }
-
-    while (size-- && !corrupted)
-    {
-        buffer_[buffer_index_++] = static_cast<boost::crypt::uint8_t>(static_cast<boost::crypt::uint8_t>(*data) &
-                                                                      static_cast<boost::crypt::uint8_t>(0xFF));
-        low_ += 8U;
-
-        if (BOOST_CRYPT_UNLIKELY(low_ == 0))
-        {
-            // Would indicate size_t rollover which should not happen on a single data stream
-            // LCOV_EXCL_START
-            ++high_;
-            if (high_ == 0)
-            {
-                corrupted = true;
-                return hasher_state::input_too_long;
-            }
-            // LCOV_EXCL_STOP
-        }
-
-        if (buffer_index_ == buffer_.size())
-        {
-            sha256_process_message_block();
-        }
-
-        ++data;
-    }
-
-    return hasher_state::success;
-}
-
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_hasher::init() -> void
-{
-    // https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-    intermediate_hash_[0] = 0x6A09E667;
-    intermediate_hash_[1] = 0xBB67AE85;
-    intermediate_hash_[2] = 0x3C6EF372;
-    intermediate_hash_[3] = 0xA54FF53A;
-    intermediate_hash_[4] = 0x510E527F;
-    intermediate_hash_[5] = 0x9B05688C;
-    intermediate_hash_[6] = 0x1F83D9AB;
-    intermediate_hash_[7] = 0x5BE0CD19;
-
-    buffer_.fill(0);
-    buffer_index_ = 0UL;
-    low_ = 0UL;
-    high_ = 0UL;
-    computed = false;
-    corrupted = false;
-}
-
-template <typename ByteType>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_hasher::process_byte(ByteType byte) noexcept -> hasher_state
-{
-    static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
-    const auto value {static_cast<boost::crypt::uint8_t>(byte)};
-    return sha256_update(&value, 1UL);
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    if (!utility::is_null(buffer))
-    {
-        return sha256_update(buffer, byte_count);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    #ifndef BOOST_CRYPT_HAS_CUDA
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* char_ptr {reinterpret_cast<const char *>(std::addressof(*buffer))};
-        const auto* data {reinterpret_cast<const unsigned char *>(char_ptr)};
-        return sha256_update(data, byte_count * 2U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #else
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
-        return sha256_update(data, byte_count * 2U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #endif
-}
-
-template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256_hasher::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
-{
-    #ifndef BOOST_CRYPT_HAS_CUDA
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* char_ptr {reinterpret_cast<const char *>(std::addressof(*buffer))};
-        const auto* data {reinterpret_cast<const unsigned char *>(char_ptr)};
-        return sha256_update(data, byte_count * 4U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #else
-
-    if (!utility::is_null(buffer))
-    {
-        const auto* data {reinterpret_cast<const unsigned char*>(buffer)};
-        return sha256_update(data, byte_count * 4U);
-    }
-    else
-    {
-        return hasher_state::null;
-    }
-
-    #endif
-}
-
-constexpr auto sha256_hasher::get_digest() noexcept -> sha256_hasher::return_type
-{
-    sha256_hasher::return_type digest{};
-
-    if (corrupted)
-    {
-        // Return empty message on corruption
-        return digest;
-    }
-    if (!computed)
-    {
-        pad_message();
-
-        // Overwrite whatever is in the buffer in case it is sensitive
-        buffer_.fill(0);
-        low_ = 0U;
-        high_ = 0U;
-        computed = true;
-    }
-
-    for (boost::crypt::size_t i {}; i < digest.size(); ++i)
-    {
-        digest[i] = static_cast<boost::crypt::uint8_t>(intermediate_hash_[i >> 2U] >> 8U * (3U - (i & 0x03U)));
-    }
-
-    return digest;
-}
-
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(T begin, T end) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(T begin, T end) noexcept -> sha256_hasher::return_type
 {
     if (end < begin)
     {
@@ -460,7 +220,7 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(T begin, T end) noexcept -> sha256
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -471,7 +231,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -481,7 +241,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str
     return detail::sha256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const boost::crypt::uint8_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const boost::crypt::uint8_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -492,7 +252,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const boost::cr
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -502,7 +262,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const boost::cr
     return detail::sha256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -513,7 +273,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t*
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -523,7 +283,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t*
     return detail::sha256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -534,7 +294,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t*
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -546,7 +306,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t*
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -557,7 +317,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* 
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -690,7 +450,7 @@ BOOST_CRYPT_EXPORT inline auto sha256_file(std::string_view filepath) noexcept -
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-constexpr auto sha256(std::span<T, extent> data) noexcept -> sha256_hasher::return_type
+inline auto sha256(std::span<T, extent> data) noexcept -> sha256_hasher::return_type
 {
     return detail::sha256(data.begin(), data.end());
 }
@@ -700,7 +460,7 @@ constexpr auto sha256(std::span<T, extent> data) noexcept -> sha256_hasher::retu
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(cuda::std::span<T, extent> data) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED inline auto sha256(cuda::std::span<T, extent> data) noexcept -> sha256_hasher::return_type
 {
     return detail::sha256(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha256.hpp
+++ b/include/boost/crypt/hash/sha256.hpp
@@ -35,7 +35,7 @@ BOOST_CRYPT_EXPORT class sha256_hasher : public hash_detail::hasher_base_512<32U
 {
 public:
 
-    BOOST_CRYPT_GPU_ENABLED sha256_hasher() { this->init(); }
+    BOOST_CRYPT_GPU_ENABLED sha256_hasher() noexcept { this->init(); }
 
     BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
 

--- a/include/boost/crypt/utility/config.hpp
+++ b/include/boost/crypt/utility/config.hpp
@@ -59,7 +59,9 @@
 
 // ----- Assertions -----
 #ifndef BOOST_CRYPT_HAS_CUDA
-#  include <cassert>
+#  ifndef BOOST_CRYPT_BUILD_MODULE
+#    include <cassert>
+#  endif
 #  define BOOST_CRYPT_ASSERT(x) assert(x)
 #  define BOOST_CRYPT_ASSERT_MSG(expr, msg) assert((expr)&&(msg))
 #else
@@ -70,6 +72,9 @@
 
 // ----- Has something -----
 // C++17
+
+#ifndef BOOST_CRYPT_BUILD_MODULE
+
 #ifndef BOOST_CRYPT_HAS_CUDA
 #  if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    if __has_include(<string_view>)
@@ -92,6 +97,14 @@
 #    endif // Has <span>
 #  endif // C++20
 #endif // BOOST_CRYPT_HAS_CUDA
+
+#else // We are building a module
+
+// If someone is building the module successfully they defintiely have the above things
+#  define BOOST_CRYPT_HAS_STRING_VIEW
+#  define BOOST_CRYPT_HAS_SPAN
+
+#endif // BOOST_CRYPT_BUILD_MODULE
 
 #if defined(__has_builtin)
 #define BOOST_CRYPT_HAS_BUILTIN(x) __has_builtin(x)

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -44,6 +44,9 @@ project : requirements
   ;
 
 
+# ODR Violations
+run link_1.cpp link_2.cpp link_3.cpp ;
+
 # Basic Testing
 run quick.cpp ;
 run test_md5.cpp ;

--- a/test/link_1.cpp
+++ b/test/link_1.cpp
@@ -1,0 +1,26 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/crypt/hash/md5.hpp>
+#include <boost/crypt/hash/sha1.hpp>
+#include <boost/crypt/hash/sha256.hpp>
+
+void test_odr_use();
+
+// LCOV_EXCL_START
+template <typename T>
+void test()
+{
+    T hasher;
+    static_cast<void>(hasher);
+    test_odr_use();
+}
+
+void f1()
+{
+    test<boost::crypt::md5_hasher>();
+    test<boost::crypt::sha256_hasher>();
+    test<boost::crypt::sha1_hasher>();
+}
+// LCOV_EXCL_STOP

--- a/test/link_2.cpp
+++ b/test/link_2.cpp
@@ -1,0 +1,26 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/crypt/hash/md5.hpp>
+#include <boost/crypt/hash/sha1.hpp>
+#include <boost/crypt/hash/sha256.hpp>
+
+void test_odr_use();
+
+// LCOV_EXCL_START
+template <typename T>
+void test()
+{
+    T hasher;
+    static_cast<void>(hasher);
+    test_odr_use();
+}
+
+void f2()
+{
+    test<boost::crypt::md5_hasher>();
+    test<boost::crypt::sha256_hasher>();
+    test<boost::crypt::sha1_hasher>();
+}
+// LCOV_EXCL_STOP

--- a/test/link_3.cpp
+++ b/test/link_3.cpp
@@ -1,0 +1,22 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/crypt/hash/md5.hpp>
+#include <boost/crypt/hash/sha1.hpp>
+#include <boost/crypt/hash/sha256.hpp>
+
+// LCOV_EXCL_START
+void f1();
+void f2();
+
+int main()
+{
+    f1();
+    f2();
+}
+
+void test_odr_use()
+{
+}
+// LCOV_EXCL_STOP


### PR DESCRIPTION
Makes a unified base class for the 512-bit hashers (SHA1, SHA224, SHA256, and MD5). Removes constexpr support due to unknown side effects of `constexpr` computation. Stick with header only model to continue CUDA, metal, etc support.

Closes: #34 
Closes: #38 
Closes: #39 