### PR TITLE
Add additional `process_bytes` interfaces

### DIFF
--- a/doc/crypt/md5.adoc
+++ b/doc/crypt/md5.adoc
@@ -123,6 +123,32 @@ class md5_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> return_type;
 };
 

--- a/doc/crypt/sha1.adoc
+++ b/doc/crypt/sha1.adoc
@@ -123,6 +123,32 @@ class sha1_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> boost::crypt::array<boost::crypt::uint8_t, 20>;
 };
 

--- a/doc/crypt/sha256.adoc
+++ b/doc/crypt/sha256.adoc
@@ -123,6 +123,32 @@ class sha256_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> return_type;
 };
 

--- a/doc/crypt/sha384.adoc
+++ b/doc/crypt/sha384.adoc
@@ -123,6 +123,32 @@ class sha384_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> return_type;
 };
 

--- a/doc/crypt/sha512.adoc
+++ b/doc/crypt/sha512.adoc
@@ -123,6 +123,32 @@ class sha512_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> return_type;
 };
 

--- a/doc/crypt/sha512_224.adoc
+++ b/doc/crypt/sha512_224.adoc
@@ -123,6 +123,32 @@ class sha512_224_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> return_type;
 };
 

--- a/doc/crypt/sha512_256.adoc
+++ b/doc/crypt/sha512_256.adoc
@@ -123,6 +123,32 @@ class sha512_256_hasher
     template <typename ForwardIter>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     inline auto get_digest() noexcept -> return_type;
 };
 

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -52,6 +52,32 @@ public:
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     virtual BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
 
 protected:
@@ -294,6 +320,56 @@ BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_ha
 
     return hasher_state::success;
 }
+
+#ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(std::string_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(std::u16string_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(std::u32string_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(std::wstring_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+#endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+#ifdef BOOST_CRYPT_HAS_SPAN
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename T, boost::crypt::size_t extent>
+inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(std::span<T, extent> data) noexcept -> hasher_state
+{
+    return process_bytes(data.begin(), data.size());
+}
+
+#endif // BOOST_CRYPT_HAS_SPAN
+
+#ifdef BOOST_CRYPT_HAS_CUDA
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename T, boost::crypt::size_t extent>
+inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
+{
+    return process_bytes(data.begin(), data.size());
+}
+
+#endif // BOOST_CRYPT_HAS_SPAN
 
 } // namespace hash_detail
 } // namespace crypt

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -364,7 +364,7 @@ inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
 template <typename T, boost::crypt::size_t extent>
-inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED inline auto hasher_base_512<digest_size, intermediate_hash_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
 {
     return process_bytes(data.begin(), data.size());
 }

--- a/include/boost/crypt/hash/detail/hasher_base_512.hpp
+++ b/include/boost/crypt/hash/detail/hasher_base_512.hpp
@@ -34,6 +34,26 @@ template <boost::crypt::size_t digest_size,
           boost::crypt::size_t intermediate_hash_size>
 class hasher_base_512
 {
+protected:
+
+    // This function should be pure virtual but GCC < 9 won't accept that
+    // LCOV_EXCL_START
+    virtual BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void {};
+    // LCOV_EXCL_STOP
+
+    BOOST_CRYPT_GPU_ENABLED inline auto pad_message() noexcept -> void;
+
+    template <typename ForwardIter>
+    BOOST_CRYPT_GPU_ENABLED inline auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
+
+    boost::crypt::array<boost::crypt::uint32_t, intermediate_hash_size> intermediate_hash_ {};
+    boost::crypt::array<boost::crypt::uint8_t , 64U> buffer_ {};
+    boost::crypt::size_t buffer_index_ {};
+    boost::crypt::size_t low_ {};
+    boost::crypt::size_t high_ {};
+    bool computed {};
+    bool corrupted {};
+
 public:
 
     using return_type = boost::crypt::array<boost::crypt::uint8_t, digest_size>;
@@ -79,26 +99,6 @@ public:
     #endif // BOOST_CRYPT_HAS_CUDA
 
     virtual BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
-
-protected:
-
-    // This function should be pure virtual but GCC < 9 won't accept that
-    // LCOV_EXCL_START
-    virtual BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void {};
-    // LCOV_EXCL_STOP
-
-    BOOST_CRYPT_GPU_ENABLED inline auto pad_message() noexcept -> void;
-
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED inline auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
-
-    boost::crypt::array<boost::crypt::uint32_t, intermediate_hash_size> intermediate_hash_ {};
-    boost::crypt::array<boost::crypt::uint8_t , 64U> buffer_ {};
-    boost::crypt::size_t buffer_index_ {};
-    boost::crypt::size_t low_ {};
-    boost::crypt::size_t high_ {};
-    bool computed {};
-    bool corrupted {};
 };
 
 template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>

--- a/include/boost/crypt/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt/hash/detail/sha512_base.hpp
@@ -360,7 +360,7 @@ auto sha512_base<digest_size>::process_message_block() noexcept -> void
 {
     #ifdef BOOST_CRYPT_HAS_CUDA
 
-    BOOST_CRYPT_INLINE_CONSTEXPR boost::crypt::array<boost::crypt::uint64_t, 80U> sha512_k = {
+    constexpr boost::crypt::array<boost::crypt::uint64_t, 80U> sha512_k = {
             0x428A2F98D728AE22ULL, 0x7137449123EF65CDULL, 0xB5C0FBCFEC4D3B2FULL,
             0xE9B5DBA58189DBBCULL, 0x3956C25BF348B538ULL, 0x59F111F1B605D019ULL,
             0x923F82A4AF194F9BULL, 0xAB1C5ED5DA6D8118ULL, 0xD807AA98A3030242ULL,

--- a/include/boost/crypt/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt/hash/detail/sha512_base.hpp
@@ -607,7 +607,7 @@ inline auto sha512_base<digest_size>::process_bytes(std::span<T, extent> data) n
 
 #ifdef BOOST_CRYPT_HAS_CUDA
 
-template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <boost::crypt::size_t digest_size>
 template <typename T, boost::crypt::size_t extent>
 BOOST_CRYPT_GPU_ENABLED inline auto sha512_base<digest_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
 {

--- a/include/boost/crypt/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt/hash/detail/sha512_base.hpp
@@ -85,6 +85,32 @@ public:
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
     BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
+    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+
+    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+    #ifdef BOOST_CRYPT_HAS_SPAN
+
+    template <typename T, boost::crypt::size_t extent>
+    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_SPAN
+
+    #ifdef BOOST_CRYPT_HAS_CUDA
+
+    template <typename T, boost::crypt::size_t extent>
+    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+
+    #endif // BOOST_CRYPT_HAS_CUDA
+
     BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
 };
 
@@ -539,6 +565,56 @@ auto sha512_base<digest_size>::init() noexcept -> void
 
     init(sha_type());
 }
+
+#ifdef BOOST_CRYPT_HAS_STRING_VIEW
+
+template <boost::crypt::size_t digest_size>
+inline auto sha512_base<digest_size>::process_bytes(std::string_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+template <boost::crypt::size_t digest_size>
+inline auto sha512_base<digest_size>::process_bytes(std::u16string_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+template <boost::crypt::size_t digest_size>
+inline auto sha512_base<digest_size>::process_bytes(std::u32string_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+template <boost::crypt::size_t digest_size>
+inline auto sha512_base<digest_size>::process_bytes(std::wstring_view str) noexcept -> hasher_state
+{
+    return process_bytes(str.begin(), str.size());
+}
+
+#endif // BOOST_CRYPT_HAS_STRING_VIEW
+
+#ifdef BOOST_CRYPT_HAS_SPAN
+
+template <boost::crypt::size_t digest_size>
+template <typename T, boost::crypt::size_t extent>
+inline auto sha512_base<digest_size>::process_bytes(std::span<T, extent> data) noexcept -> hasher_state
+{
+    return process_bytes(data.begin(), data.size());
+}
+
+#endif // BOOST_CRYPT_HAS_SPAN
+
+#ifdef BOOST_CRYPT_HAS_CUDA
+
+template <boost::crypt::size_t digest_size, boost::crypt::size_t intermediate_hash_size>
+template <typename T, boost::crypt::size_t extent>
+BOOST_CRYPT_GPU_ENABLED inline auto sha512_base<digest_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
+{
+    return process_bytes(data.begin(), data.size());
+}
+
+#endif // BOOST_CRYPT_HAS_SPAN
 
 } // namespace hash_detail
 } // namespace crypt

--- a/test/test_sha224.cpp
+++ b/test/test_sha224.cpp
@@ -85,6 +85,21 @@ void string_view_test()
                 // LCOV_EXCL_STOP
             }
         }
+
+        boost::crypt::sha224_hasher hasher;
+        const auto current_state = hasher.process_bytes(string_view_message);
+        BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+        const auto result2 = hasher.get_digest();
+        for (std::size_t i {}; i < message_result.size(); ++i)
+        {
+            if (!BOOST_TEST_EQ(result2[i], valid_result[i]))
+            {
+                // LCOV_EXCL_START
+                std::cerr << "Failure with: " << std::get<0>(test_value) << '\n';
+                break;
+                // LCOV_EXCL_STOP
+            }
+        }
     }
     #endif
 }
@@ -325,6 +340,16 @@ void test_span()
     for (std::size_t i {}; i < res.size(); ++i)
     {
         BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    boost::crypt::sha224_hasher hasher;
+    auto current_state = hasher.process_bytes(byte_span);
+    BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+    const auto res_2 = hasher.get_digest();
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res_2[i], expected_res[i]);
     }
 
     #endif // BOOST_CRYPT_HAS_SPAN

--- a/test/test_sha256.cpp
+++ b/test/test_sha256.cpp
@@ -90,6 +90,22 @@ void string_view_test()
                 // LCOV_EXCL_STOP
             }
         }
+
+        boost::crypt::sha256_hasher hasher;
+        const auto current_state = hasher.process_bytes(string_view_message);
+        BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+        const auto result2 = hasher.get_digest();
+        for (std::size_t i {}; i < message_result.size(); ++i)
+        {
+            if (!BOOST_TEST_EQ(result2[i], valid_result[i]))
+            {
+                // LCOV_EXCL_START
+                std::cerr << "Failure with: " << std::get<0>(test_value) << '\n';
+                break;
+                // LCOV_EXCL_STOP
+            }
+        }
+
     }
     #endif
 }
@@ -330,6 +346,16 @@ void test_span()
     for (std::size_t i {}; i < res.size(); ++i)
     {
         BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    boost::crypt::sha256_hasher hasher;
+    auto current_state = hasher.process_bytes(byte_span);
+    BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+    const auto res_2 = hasher.get_digest();
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res_2[i], expected_res[i]);
     }
 
     #endif // BOOST_CRYPT_HAS_SPAN

--- a/test/test_sha384.cpp
+++ b/test/test_sha384.cpp
@@ -104,6 +104,21 @@ void string_view_test()
                 // LCOV_EXCL_STOP
             }
         }
+
+        boost::crypt::sha384_hasher hasher;
+        const auto current_state = hasher.process_bytes(string_view_message);
+        BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+        const auto result2 = hasher.get_digest();
+        for (std::size_t i {}; i < message_result.size(); ++i)
+        {
+            if (!BOOST_TEST_EQ(result2[i], valid_result[i]))
+            {
+                // LCOV_EXCL_START
+                std::cerr << "Failure with: " << std::get<0>(test_value) << '\n';
+                break;
+                // LCOV_EXCL_STOP
+            }
+        }
     }
     #endif
 }
@@ -344,6 +359,16 @@ void test_span()
     for (std::size_t i {}; i < res.size(); ++i)
     {
         BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    boost::crypt::sha384_hasher hasher;
+    auto current_state = hasher.process_bytes(byte_span);
+    BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+    const auto res_2 = hasher.get_digest();
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res_2[i], expected_res[i]);
     }
 
     #endif // BOOST_CRYPT_HAS_SPAN

--- a/test/test_sha512.cpp
+++ b/test/test_sha512.cpp
@@ -110,6 +110,21 @@ void string_view_test()
                 // LCOV_EXCL_STOP
             }
         }
+
+        boost::crypt::sha512_hasher hasher;
+        const auto current_state = hasher.process_bytes(string_view_message);
+        BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+        const auto result2 = hasher.get_digest();
+        for (std::size_t i {}; i < message_result.size(); ++i)
+        {
+            if (!BOOST_TEST_EQ(result2[i], valid_result[i]))
+            {
+                // LCOV_EXCL_START
+                std::cerr << "Failure with: " << std::get<0>(test_value) << '\n';
+                break;
+                // LCOV_EXCL_STOP
+            }
+        }
     }
     #endif
 }
@@ -350,6 +365,16 @@ void test_span()
     for (std::size_t i {}; i < res.size(); ++i)
     {
         BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    boost::crypt::sha512_hasher hasher;
+    auto current_state = hasher.process_bytes(byte_span);
+    BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+    const auto res_2 = hasher.get_digest();
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res_2[i], expected_res[i]);
     }
 
     #endif // BOOST_CRYPT_HAS_SPAN

--- a/test/test_sha512_224.cpp
+++ b/test/test_sha512_224.cpp
@@ -98,6 +98,21 @@ void string_view_test()
                 // LCOV_EXCL_STOP
             }
         }
+
+        boost::crypt::sha512_224_hasher hasher;
+        const auto current_state = hasher.process_bytes(string_view_message);
+        BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+        const auto result2 = hasher.get_digest();
+        for (std::size_t i {}; i < message_result.size(); ++i)
+        {
+            if (!BOOST_TEST_EQ(result2[i], valid_result[i]))
+            {
+                // LCOV_EXCL_START
+                std::cerr << "Failure with: " << std::get<0>(test_value) << '\n';
+                break;
+                // LCOV_EXCL_STOP
+            }
+        }
     }
     #endif
 }
@@ -338,6 +353,16 @@ void test_span()
     for (std::size_t i {}; i < res.size(); ++i)
     {
         BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    boost::crypt::sha512_224_hasher hasher;
+    auto current_state = hasher.process_bytes(byte_span);
+    BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+    const auto res_2 = hasher.get_digest();
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res_2[i], expected_res[i]);
     }
 
     #endif // BOOST_CRYPT_HAS_SPAN

--- a/test/test_sha512_256.cpp
+++ b/test/test_sha512_256.cpp
@@ -98,6 +98,21 @@ void string_view_test()
                 // LCOV_EXCL_STOP
             }
         }
+
+        boost::crypt::sha512_256_hasher hasher;
+        const auto current_state = hasher.process_bytes(string_view_message);
+        BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+        const auto result2 = hasher.get_digest();
+        for (std::size_t i {}; i < message_result.size(); ++i)
+        {
+            if (!BOOST_TEST_EQ(result2[i], valid_result[i]))
+            {
+                // LCOV_EXCL_START
+                std::cerr << "Failure with: " << std::get<0>(test_value) << '\n';
+                break;
+                // LCOV_EXCL_STOP
+            }
+        }
     }
     #endif
 }
@@ -338,6 +353,16 @@ void test_span()
     for (std::size_t i {}; i < res.size(); ++i)
     {
         BOOST_TEST_EQ(res[i], expected_res[i]);
+    }
+
+    boost::crypt::sha512_256_hasher hasher;
+    auto current_state = hasher.process_bytes(byte_span);
+    BOOST_TEST(current_state == boost::crypt::hasher_state::success);
+    const auto res_2 = hasher.get_digest();
+
+    for (std::size_t i {}; i < res.size(); ++i)
+    {
+        BOOST_TEST_EQ(res_2[i], expected_res[i]);
     }
 
     #endif // BOOST_CRYPT_HAS_SPAN


### PR DESCRIPTION
Adds `std::string_view`, `std::span`, and `cuda::std::span` interfaces to `process_bytes` functions. These are arguably safer and more idiomatic modern C++

Closes: #54 