### PR TITLE
Re-enable constexpr hashing

### DIFF
--- a/include/boost/crypt/hash/detail/sha224_256_hasher.hpp
+++ b/include/boost/crypt/hash/detail/sha224_256_hasher.hpp
@@ -62,7 +62,7 @@ public:
 
     BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void { init(is_sha224()); }
 
-    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> sha_224_256_hasher::return_type { return base_class::get_base_digest(); }
+    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> typename sha_224_256_hasher::return_type { return base_class::get_base_digest(); }
 };
 
 // Initial values for SHA224

--- a/include/boost/crypt/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt/hash/detail/sha512_base.hpp
@@ -50,73 +50,73 @@ private:
     bool computed_ {};
     bool corrupted_ {};
 
-    BOOST_CRYPT_GPU_ENABLED inline auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 28U>&) noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 28U>&) noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED inline auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 32U>&) noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 32U>&) noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED inline auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 48U>&) noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 48U>&) noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED inline auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 64U>&) noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init(const boost::crypt::integral_constant<boost::crypt::size_t, 64U>&) noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_message_block() noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED inline auto pad_message() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto pad_message() noexcept -> void;
 
     template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED inline auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state;
 
 public:
 
     using return_type = boost::crypt::array<boost::crypt::uint8_t, digest_size>;
 
-    BOOST_CRYPT_GPU_ENABLED sha512_base() noexcept { init(); }
+    BOOST_CRYPT_GPU_ENABLED constexpr sha512_base() noexcept { init(); }
 
-    BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void;
 
     template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_byte(ByteType byte) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool> = true>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state;
 
     #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-    inline auto process_bytes(std::string_view str) noexcept -> hasher_state;
+    constexpr auto process_bytes(std::string_view str) noexcept -> hasher_state;
 
-    inline auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
+    constexpr auto process_bytes(std::u16string_view str) noexcept -> hasher_state;
 
-    inline auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
+    constexpr auto process_bytes(std::u32string_view str) noexcept -> hasher_state;
 
-    inline auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
+    constexpr auto process_bytes(std::wstring_view str) noexcept -> hasher_state;
 
     #endif // BOOST_CRYPT_HAS_STRING_VIEW
 
     #ifdef BOOST_CRYPT_HAS_SPAN
 
     template <typename T, boost::crypt::size_t extent>
-    inline auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
+    constexpr auto process_bytes(std::span<T, extent> data) noexcept -> hasher_state;
 
     #endif // BOOST_CRYPT_HAS_SPAN
 
     #ifdef BOOST_CRYPT_HAS_CUDA
 
     template <typename T, boost::crypt::size_t extent>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state;
 
     #endif // BOOST_CRYPT_HAS_CUDA
 
-    BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type;
 };
 
 template <boost::crypt::size_t digest_size>
 template <typename ByteType>
-auto sha512_base<digest_size>::process_byte(ByteType byte) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_byte(ByteType byte) noexcept -> hasher_state
 {
     static_assert(boost::crypt::is_convertible_v<ByteType, boost::crypt::uint8_t>, "Byte must be convertible to uint8_t");
     const auto value {static_cast<boost::crypt::uint8_t>(byte)};
@@ -125,7 +125,7 @@ auto sha512_base<digest_size>::process_byte(ByteType byte) noexcept -> hasher_st
 
 template <boost::crypt::size_t digest_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 1, bool>>
-auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     if (!utility::is_null(buffer))
     {
@@ -139,7 +139,7 @@ auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::s
 
 template <boost::crypt::size_t digest_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 2, bool>>
-auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -171,7 +171,7 @@ auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::s
 
 template <boost::crypt::size_t digest_size>
 template <typename ForwardIter, boost::crypt::enable_if_t<sizeof(typename utility::iterator_traits<ForwardIter>::value_type) == 4, bool>>
-auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::size_t byte_count) noexcept -> hasher_state
 {
     #ifndef BOOST_CRYPT_HAS_CUDA
 
@@ -202,7 +202,7 @@ auto sha512_base<digest_size>::process_bytes(ForwardIter buffer, boost::crypt::s
 }
 
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::get_digest() noexcept -> sha512_base::return_type
+constexpr auto sha512_base<digest_size>::get_digest() noexcept -> sha512_base::return_type
 {
     return_type digest {};
 
@@ -229,7 +229,7 @@ auto sha512_base<digest_size>::get_digest() noexcept -> sha512_base::return_type
 }
 
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::pad_message() noexcept -> void
+constexpr auto sha512_base<digest_size>::pad_message() noexcept -> void
 {
     constexpr boost::crypt::size_t message_length_start_index {112U};
 
@@ -319,34 +319,34 @@ BOOST_CRYPT_INLINE_CONSTEXPR boost::crypt::array<boost::crypt::uint64_t, 80U> sh
 #endif
 
 // See section 4.1.3
-BOOST_CRYPT_GPU_ENABLED inline auto big_sigma0(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
+BOOST_CRYPT_GPU_ENABLED constexpr auto big_sigma0(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
 {
     return detail::rotr(x, 28UL) ^ detail::rotr(x, 34UL) ^ detail::rotr(x, 39UL);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto big_sigma1(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
+BOOST_CRYPT_GPU_ENABLED constexpr auto big_sigma1(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
 {
     return detail::rotr(x, 14UL) ^ detail::rotr(x, 18UL) ^ detail::rotr(x, 41UL);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto little_sigma0(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
+BOOST_CRYPT_GPU_ENABLED constexpr auto little_sigma0(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
 {
     return detail::rotr(x, 1UL) ^ detail::rotr(x, 8UL) ^ (x >> 7UL);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto little_sigma1(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
+BOOST_CRYPT_GPU_ENABLED constexpr auto little_sigma1(const boost::crypt::uint64_t x) noexcept -> boost::crypt::uint64_t
 {
     return detail::rotr(x, 19UL) ^ detail::rotr(x, 61UL) ^ (x >> 6UL);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto sha_ch(const boost::crypt::uint64_t x,
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha_ch(const boost::crypt::uint64_t x,
                                            const boost::crypt::uint64_t y,
                                            const boost::crypt::uint64_t z) -> boost::crypt::uint64_t
 {
     return (x & y) ^ ((~x) & z);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto sha_maj(const boost::crypt::uint64_t x,
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha_maj(const boost::crypt::uint64_t x,
                                             const boost::crypt::uint64_t y,
                                             const boost::crypt::uint64_t z) -> boost::crypt::uint64_t
 {
@@ -356,7 +356,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha_maj(const boost::crypt::uint64_t x,
 } // namespace sha512_detail
 
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::process_message_block() noexcept -> void
+constexpr auto sha512_base<digest_size>::process_message_block() noexcept -> void
 {
     #ifdef BOOST_CRYPT_HAS_CUDA
 
@@ -452,7 +452,7 @@ auto sha512_base<digest_size>::process_message_block() noexcept -> void
 
 template <boost::crypt::size_t digest_size>
 template <typename ForwardIter>
-auto sha512_base<digest_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::update(ForwardIter data, boost::crypt::size_t size) noexcept -> hasher_state
 {
     if (size == 0U)
     {
@@ -499,7 +499,7 @@ auto sha512_base<digest_size>::update(ForwardIter data, boost::crypt::size_t siz
 
 // SHA512/224
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 28U> &) noexcept -> void
+constexpr auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 28U> &) noexcept -> void
 {
     intermediate_hash_[0] = 0x8C3D37C819544DA2UL;
     intermediate_hash_[1] = 0x73E1996689DCD4D6UL;
@@ -513,7 +513,7 @@ auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t
 
 // SHA512/256
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 32U> &) noexcept -> void
+constexpr auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 32U> &) noexcept -> void
 {
     intermediate_hash_[0] = 0x22312194FC2BF72CUL;
     intermediate_hash_[1] = 0x9F555FA3C84C64C2UL;
@@ -527,7 +527,7 @@ auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t
 
 // SHA384
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 48U> &) noexcept -> void
+constexpr auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 48U> &) noexcept -> void
 {
     intermediate_hash_[0] = 0xcbbb9d5dc1059ed8UL;
     intermediate_hash_[1] = 0x629a292a367cd507UL;
@@ -541,7 +541,7 @@ auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t
 
 // SHA512
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 64U> &) noexcept -> void
+constexpr auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t, 64U> &) noexcept -> void
 {
     intermediate_hash_[0] = 0x6a09e667f3bcc908UL;
     intermediate_hash_[1] = 0xbb67ae8584caa73bUL;
@@ -554,7 +554,7 @@ auto sha512_base<digest_size>::init(const integral_constant<boost::crypt::size_t
 }
 
 template <boost::crypt::size_t digest_size>
-auto sha512_base<digest_size>::init() noexcept -> void
+constexpr auto sha512_base<digest_size>::init() noexcept -> void
 {
     buffer_.fill(0);
     buffer_index_ = 0U;
@@ -569,25 +569,25 @@ auto sha512_base<digest_size>::init() noexcept -> void
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
 template <boost::crypt::size_t digest_size>
-inline auto sha512_base<digest_size>::process_bytes(std::string_view str) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(std::string_view str) noexcept -> hasher_state
 {
     return process_bytes(str.begin(), str.size());
 }
 
 template <boost::crypt::size_t digest_size>
-inline auto sha512_base<digest_size>::process_bytes(std::u16string_view str) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(std::u16string_view str) noexcept -> hasher_state
 {
     return process_bytes(str.begin(), str.size());
 }
 
 template <boost::crypt::size_t digest_size>
-inline auto sha512_base<digest_size>::process_bytes(std::u32string_view str) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(std::u32string_view str) noexcept -> hasher_state
 {
     return process_bytes(str.begin(), str.size());
 }
 
 template <boost::crypt::size_t digest_size>
-inline auto sha512_base<digest_size>::process_bytes(std::wstring_view str) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(std::wstring_view str) noexcept -> hasher_state
 {
     return process_bytes(str.begin(), str.size());
 }
@@ -598,7 +598,7 @@ inline auto sha512_base<digest_size>::process_bytes(std::wstring_view str) noexc
 
 template <boost::crypt::size_t digest_size>
 template <typename T, boost::crypt::size_t extent>
-inline auto sha512_base<digest_size>::process_bytes(std::span<T, extent> data) noexcept -> hasher_state
+constexpr auto sha512_base<digest_size>::process_bytes(std::span<T, extent> data) noexcept -> hasher_state
 {
     return process_bytes(data.begin(), data.size());
 }
@@ -609,7 +609,7 @@ inline auto sha512_base<digest_size>::process_bytes(std::span<T, extent> data) n
 
 template <boost::crypt::size_t digest_size>
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512_base<digest_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_base<digest_size>::process_bytes(cuda::std::span<T, extent> data) noexcept -> hasher_state
 {
     return process_bytes(data.begin(), data.size());
 }

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -44,7 +44,7 @@ public:
 private:
 
     // Needed to keep process_message_block private with CRTP
-    friend class hasher_base_512<16U, 4U, md5_hasher>;
+    friend class hash_detail::hasher_base_512<16U, 4U, md5_hasher>;
 
     BOOST_CRYPT_GPU_ENABLED constexpr auto process_message_block() noexcept -> void;
 };

--- a/include/boost/crypt/hash/md5.hpp
+++ b/include/boost/crypt/hash/md5.hpp
@@ -31,24 +31,27 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class md5_hasher final : public hash_detail::hasher_base_512<16U, 4U>
+BOOST_CRYPT_EXPORT class md5_hasher final : public hash_detail::hasher_base_512<16U, 4U, md5_hasher>
 {
 public:
 
-    BOOST_CRYPT_GPU_ENABLED md5_hasher() noexcept { this->init(); }
+    BOOST_CRYPT_GPU_ENABLED constexpr md5_hasher() noexcept { this->init(); }
 
-    BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED inline auto get_digest() noexcept -> return_type override;
+    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> return_type;
 
 private:
 
-    BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void override;
+    // Needed to keep process_message_block private with CRTP
+    friend class hasher_base_512<16U, 4U, md5_hasher>;
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_message_block() noexcept -> void;
 };
 
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::init() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::init() noexcept -> void
 {
-    hash_detail::hasher_base_512<16U, 4U>::base_init();
+    hash_detail::hasher_base_512<16U, 4U, md5_hasher>::base_init();
 
     intermediate_hash_[0] = 0x67452301;
     intermediate_hash_[1] = 0xefcdab89;
@@ -60,48 +63,48 @@ BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::init() noexcept -> void
 // Section 18.5
 namespace md5_body_detail {
 
-BOOST_CRYPT_GPU_ENABLED inline auto F(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED constexpr auto F(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return (x & y) | ((~x) & z);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto G(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED constexpr auto G(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return (x & z) | (y & (~z));
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto H(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED constexpr auto H(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return x ^ y ^ z;
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto I(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
+BOOST_CRYPT_GPU_ENABLED constexpr auto I(boost::crypt::uint32_t x, boost::crypt::uint32_t y, boost::crypt::uint32_t z) noexcept
 {
     return y ^ (x | (~z));
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto FF(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED constexpr auto FF(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                        boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                        boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + F(b, c, d) + Mj + ti), si);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto GG(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED constexpr auto GG(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                        boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                        boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + G(b, c, d) + Mj + ti), si);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto HH(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED constexpr auto HH(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                        boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                        boost::crypt::uint32_t ti) noexcept
 {
     a = b + detail::rotl((a + H(b, c, d) + Mj + ti), si);
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto II(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
+BOOST_CRYPT_GPU_ENABLED constexpr auto II(boost::crypt::uint32_t& a, boost::crypt::uint32_t b,  boost::crypt::uint32_t c,
                                        boost::crypt::uint32_t d,  boost::crypt::uint32_t Mj, boost::crypt::uint32_t si,
                                        boost::crypt::uint32_t ti) noexcept
 {
@@ -110,7 +113,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto II(boost::crypt::uint32_t& a, boost::crypt::
 
 } // md5_body_detail
 
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_message_block() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::process_message_block() noexcept -> void
 {
     using namespace md5_body_detail;
 
@@ -215,7 +218,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::process_message_block() noexcept
     buffer_index_ = 0U;
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::get_digest() noexcept -> return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto md5_hasher::get_digest() noexcept -> return_type
 {
     return_type digest {};
     if (corrupted)
@@ -268,7 +271,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto md5_hasher::get_digest() noexcept -> return_
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto md5(T begin, T end) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto md5(T begin, T end) noexcept -> md5_hasher::return_type
 {
     if (end < begin)
     {
@@ -290,7 +293,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto md5(T begin, T end) noexcept -> md5_hasher::
 
 } // Namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -301,7 +304,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str) noex
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -311,7 +314,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char* str, boos
     return detail::md5(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const boost::crypt::uint8_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const boost::crypt::uint8_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -322,7 +325,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const boost::crypt::u
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -332,7 +335,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const boost::crypt::u
     return detail::md5(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -343,7 +346,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str) 
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char16_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -353,7 +356,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char16_t* str, 
     return detail::md5(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -364,7 +367,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str) 
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const char32_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -376,7 +379,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const char32_t* str, 
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -387,7 +390,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str) n
     return detail::md5(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto md5(const wchar_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto md5(const wchar_t* str, boost::crypt::size_t len) noexcept -> md5_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -423,22 +426,22 @@ BOOST_CRYPT_EXPORT inline auto md5(const std::wstring& str) noexcept -> md5_hash
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto md5(std::string_view str) -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto md5(std::string_view str) -> md5_hasher::return_type
 {
     return detail::md5(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto md5(std::u16string_view str) -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto md5(std::u16string_view str) -> md5_hasher::return_type
 {
     return detail::md5(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto md5(std::u32string_view str) -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto md5(std::u32string_view str) -> md5_hasher::return_type
 {
     return detail::md5(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto md5(std::wstring_view str) -> md5_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto md5(std::wstring_view str) -> md5_hasher::return_type
 {
     return detail::md5(str.begin(), str.end());
 }
@@ -520,7 +523,7 @@ BOOST_CRYPT_EXPORT inline auto md5_file(std::string_view filepath) noexcept -> m
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_type
+constexpr auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_type
 {
     return detail::md5(data.begin(), data.end());
 }
@@ -530,7 +533,7 @@ inline auto md5(std::span<T, extent> data) noexcept -> md5_hasher::return_type
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto md5(cuda::std::span<T, extent> data) noexcept -> md5_hasher::return_type
 {
     return detail::md5(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha1.hpp
+++ b/include/boost/crypt/hash/sha1.hpp
@@ -31,22 +31,26 @@
 namespace boost {
 namespace crypt {
 
-BOOST_CRYPT_EXPORT class sha1_hasher final : public hash_detail::hasher_base_512<20U, 5U>
+BOOST_CRYPT_EXPORT class sha1_hasher final : public hash_detail::hasher_base_512<20U, 5U, sha1_hasher>
 {
-public:
-
-    BOOST_CRYPT_GPU_ENABLED sha1_hasher() noexcept { this->init(); }
-
-    BOOST_CRYPT_GPU_ENABLED inline auto init() noexcept -> void;
-
 private:
 
-    BOOST_CRYPT_GPU_ENABLED inline auto process_message_block() noexcept -> void override;
+    friend class hash_detail::hasher_base_512<20U, 5U, sha1_hasher>;
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto process_message_block() noexcept -> void;
+
+public:
+
+    BOOST_CRYPT_GPU_ENABLED constexpr sha1_hasher() noexcept { this->init(); }
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto init() noexcept -> void;
+
+    BOOST_CRYPT_GPU_ENABLED constexpr auto get_digest() noexcept -> sha1_hasher::return_type { return get_base_digest(); }
 };
 
-BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::init() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::init() noexcept -> void
 {
-    hash_detail::hasher_base_512<20U, 5U>::base_init();
+    hash_detail::hasher_base_512<20U, 5U, sha1_hasher>::base_init();
 
     intermediate_hash_[0] = 0x67452301;
     intermediate_hash_[1] = 0xEFCDAB89;
@@ -57,7 +61,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::init() noexcept -> void
 
 namespace sha1_detail {
 
-BOOST_CRYPT_GPU_ENABLED inline auto round1(boost::crypt::uint32_t& A,
+BOOST_CRYPT_GPU_ENABLED constexpr auto round1(boost::crypt::uint32_t& A,
                                            boost::crypt::uint32_t& B,
                                            boost::crypt::uint32_t& C,
                                            boost::crypt::uint32_t& D,
@@ -72,7 +76,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto round1(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto round2(boost::crypt::uint32_t& A,
+BOOST_CRYPT_GPU_ENABLED constexpr auto round2(boost::crypt::uint32_t& A,
                                            boost::crypt::uint32_t& B,
                                            boost::crypt::uint32_t& C,
                                            boost::crypt::uint32_t& D,
@@ -87,7 +91,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto round2(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto round3(boost::crypt::uint32_t& A,
+BOOST_CRYPT_GPU_ENABLED constexpr auto round3(boost::crypt::uint32_t& A,
                                            boost::crypt::uint32_t& B,
                                            boost::crypt::uint32_t& C,
                                            boost::crypt::uint32_t& D,
@@ -102,7 +106,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto round3(boost::crypt::uint32_t& A,
     A = temp;
 }
 
-BOOST_CRYPT_GPU_ENABLED inline auto round4(boost::crypt::uint32_t& A,
+BOOST_CRYPT_GPU_ENABLED constexpr auto round4(boost::crypt::uint32_t& A,
                                            boost::crypt::uint32_t& B,
                                            boost::crypt::uint32_t& C,
                                            boost::crypt::uint32_t& D,
@@ -120,7 +124,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto round4(boost::crypt::uint32_t& A,
 } // Namespace sha1_detail
 
 // See definitions from the RFC on the rounds
-BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::process_message_block() noexcept -> void
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha1_hasher::process_message_block() noexcept -> void
 {
     using namespace sha1_detail;
 
@@ -247,7 +251,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha1_hasher::process_message_block() noexcep
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha1(T begin, T end) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(T begin, T end) noexcept -> sha1_hasher::return_type
 {
     if (end < begin)
     {
@@ -270,7 +274,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha1(T begin, T end) noexcept -> sha1_hasher
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -281,7 +285,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str) noe
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -291,7 +295,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char* str, boo
     return detail::sha1(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const boost::crypt::uint8_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const boost::crypt::uint8_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -302,7 +306,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const boost::crypt::
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -312,7 +316,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const boost::crypt::
     return detail::sha1(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -323,7 +327,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str)
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char16_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -333,7 +337,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char16_t* str,
     return detail::sha1(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -344,7 +348,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str)
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const char32_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -356,7 +360,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const char32_t* str,
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* str) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -367,7 +371,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str) 
     return detail::sha1(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha1(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha1_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -403,22 +407,22 @@ BOOST_CRYPT_EXPORT inline auto sha1(const std::wstring& str) noexcept -> sha1_ha
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha1(std::string_view str) -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha1(std::string_view str) -> sha1_hasher::return_type
 {
     return detail::sha1(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha1(std::u16string_view str) -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha1(std::u16string_view str) -> sha1_hasher::return_type
 {
     return detail::sha1(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha1(std::u32string_view str) -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha1(std::u32string_view str) -> sha1_hasher::return_type
 {
     return detail::sha1(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha1(std::wstring_view str) -> sha1_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha1(std::wstring_view str) -> sha1_hasher::return_type
 {
     return detail::sha1(str.begin(), str.end());
 }
@@ -500,7 +504,7 @@ BOOST_CRYPT_EXPORT inline auto sha1_file(std::string_view filepath) noexcept -> 
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+constexpr auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_type
 {
     return detail::sha1(data.begin(), data.end());
 }
@@ -510,7 +514,7 @@ inline auto sha1(std::span<T, extent> data) noexcept -> sha1_hasher::return_type
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(cuda::std::span<T, extent> data) noexcept -> sha1_hasher::return_type
 {
     return detail::sha1(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha224.hpp
+++ b/include/boost/crypt/hash/sha224.hpp
@@ -17,7 +17,7 @@ BOOST_CRYPT_EXPORT using sha224_hasher = hash_detail::sha_224_256_hasher<28U>;
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha224(T begin, T end) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(T begin, T end) noexcept -> sha224_hasher::return_type
 {
     if (end < begin)
     {
@@ -42,7 +42,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha224(T begin, T end) noexcept -> sha224_ha
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char* str) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const char* str) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -53,7 +53,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char* str) n
     return detail::sha224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const char* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -63,7 +63,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char* str, b
     return detail::sha224(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const boost::crypt::uint8_t* str) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const boost::crypt::uint8_t* str) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -74,7 +74,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const boost::crypt
     return detail::sha224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -84,7 +84,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const boost::crypt
     return detail::sha224(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char16_t* str) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const char16_t* str) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -95,7 +95,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char16_t* st
     return detail::sha224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char16_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const char16_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -105,7 +105,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char16_t* st
     return detail::sha224(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char32_t* str) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const char32_t* str) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -116,7 +116,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char32_t* st
     return detail::sha224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char32_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const char32_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -128,7 +128,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const char32_t* st
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const wchar_t* str) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const wchar_t* str) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -139,7 +139,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const wchar_t* str
     return detail::sha224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha224(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -175,22 +175,22 @@ BOOST_CRYPT_EXPORT inline auto sha224(const std::wstring& str) noexcept -> sha22
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha224(std::string_view str) -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha224(std::string_view str) -> sha224_hasher::return_type
 {
     return detail::sha224(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha224(std::u16string_view str) -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha224(std::u16string_view str) -> sha224_hasher::return_type
 {
     return detail::sha224(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha224(std::u32string_view str) -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha224(std::u32string_view str) -> sha224_hasher::return_type
 {
     return detail::sha224(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha224(std::wstring_view str) -> sha224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha224(std::wstring_view str) -> sha224_hasher::return_type
 {
     return detail::sha224(str.begin(), str.end());
 }
@@ -272,7 +272,7 @@ BOOST_CRYPT_EXPORT inline auto sha224_file(std::string_view filepath) noexcept -
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha224(std::span<T, extent> data) noexcept -> sha224_hasher::return_type
+constexpr auto sha224(std::span<T, extent> data) noexcept -> sha224_hasher::return_type
 {
     return detail::sha224(data.begin(), data.end());
 }
@@ -282,7 +282,7 @@ inline auto sha224(std::span<T, extent> data) noexcept -> sha224_hasher::return_
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha224(cuda::std::span<T, extent> data) noexcept -> sha224_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(cuda::std::span<T, extent> data) noexcept -> sha224_hasher::return_type
 {
     return detail::sha224(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha256.hpp
+++ b/include/boost/crypt/hash/sha256.hpp
@@ -17,7 +17,7 @@ BOOST_CRYPT_EXPORT using sha256_hasher = hash_detail::sha_224_256_hasher<32U>;
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(T begin, T end) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(T begin, T end) noexcept -> sha256_hasher::return_type
 {
     if (end < begin)
     {
@@ -42,7 +42,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha256(T begin, T end) noexcept -> sha256_ha
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -53,7 +53,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str) n
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -63,7 +63,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str, b
     return detail::sha256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const boost::crypt::uint8_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const boost::crypt::uint8_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -74,7 +74,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const boost::crypt
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -84,7 +84,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const boost::crypt
     return detail::sha256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -95,7 +95,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* st
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char16_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -105,7 +105,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* st
     return detail::sha256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -116,7 +116,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* st
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const char32_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -128,7 +128,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* st
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* str) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -139,7 +139,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str
     return detail::sha256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -175,22 +175,22 @@ BOOST_CRYPT_EXPORT inline auto sha256(const std::wstring& str) noexcept -> sha25
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha256(std::string_view str) -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha256(std::string_view str) -> sha256_hasher::return_type
 {
     return detail::sha256(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha256(std::u16string_view str) -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha256(std::u16string_view str) -> sha256_hasher::return_type
 {
     return detail::sha256(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha256(std::u32string_view str) -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha256(std::u32string_view str) -> sha256_hasher::return_type
 {
     return detail::sha256(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha256(std::wstring_view str) -> sha256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha256(std::wstring_view str) -> sha256_hasher::return_type
 {
     return detail::sha256(str.begin(), str.end());
 }
@@ -276,7 +276,7 @@ BOOST_CRYPT_EXPORT inline auto sha256_file(std::string_view filepath) noexcept -
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha256(std::span<T, extent> data) noexcept -> sha256_hasher::return_type
+constexpr auto sha256(std::span<T, extent> data) noexcept -> sha256_hasher::return_type
 {
     return detail::sha256(data.begin(), data.end());
 }
@@ -286,7 +286,7 @@ inline auto sha256(std::span<T, extent> data) noexcept -> sha256_hasher::return_
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(cuda::std::span<T, extent> data) noexcept -> sha256_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(cuda::std::span<T, extent> data) noexcept -> sha256_hasher::return_type
 {
     return detail::sha256(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha384.hpp
+++ b/include/boost/crypt/hash/sha384.hpp
@@ -18,7 +18,7 @@ BOOST_CRYPT_EXPORT using sha384_hasher = hash_detail::sha512_base<48U>;
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha384(T begin, T end) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(T begin, T end) noexcept -> sha384_hasher::return_type
 {
     if (end < begin)
     {
@@ -45,7 +45,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha384(T begin, T end) noexcept -> sha384_ha
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char* str) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const char* str) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -56,7 +56,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char* str) n
     return detail::sha384(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const char* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -66,7 +66,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char* str, b
     return detail::sha384(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const boost::crypt::uint8_t* str) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const boost::crypt::uint8_t* str) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -77,7 +77,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const boost::crypt
     return detail::sha384(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -87,7 +87,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const boost::crypt
     return detail::sha384(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char16_t* str) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const char16_t* str) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -98,7 +98,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char16_t* st
     return detail::sha384(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char16_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const char16_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -108,7 +108,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char16_t* st
     return detail::sha384(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char32_t* str) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const char32_t* str) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -119,7 +119,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char32_t* st
     return detail::sha384(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char32_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const char32_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -131,7 +131,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const char32_t* st
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const wchar_t* str) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const wchar_t* str) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -142,7 +142,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const wchar_t* str
     return detail::sha384(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha384(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha384_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -178,22 +178,22 @@ BOOST_CRYPT_EXPORT inline auto sha384(const std::wstring& str) noexcept -> sha38
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha384(std::string_view str) -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha384(std::string_view str) -> sha384_hasher::return_type
 {
     return detail::sha384(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha384(std::u16string_view str) -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha384(std::u16string_view str) -> sha384_hasher::return_type
 {
     return detail::sha384(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha384(std::u32string_view str) -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha384(std::u32string_view str) -> sha384_hasher::return_type
 {
     return detail::sha384(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha384(std::wstring_view str) -> sha384_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha384(std::wstring_view str) -> sha384_hasher::return_type
 {
     return detail::sha384(str.begin(), str.end());
 }
@@ -279,7 +279,7 @@ BOOST_CRYPT_EXPORT inline auto sha384_file(std::string_view filepath) noexcept -
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha384(std::span<T, extent> data) noexcept -> sha384_hasher::return_type
+constexpr auto sha384(std::span<T, extent> data) noexcept -> sha384_hasher::return_type
 {
     return detail::sha384(data.begin(), data.end());
 }
@@ -289,7 +289,7 @@ inline auto sha384(std::span<T, extent> data) noexcept -> sha384_hasher::return_
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha384(cuda::std::span<T, extent> data) noexcept -> sha384_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha384(cuda::std::span<T, extent> data) noexcept -> sha384_hasher::return_type
 {
     return detail::sha384(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha512.hpp
+++ b/include/boost/crypt/hash/sha512.hpp
@@ -18,7 +18,7 @@ BOOST_CRYPT_EXPORT using sha512_hasher = hash_detail::sha512_base<64U>;
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(T begin, T end) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(T begin, T end) noexcept -> sha512_hasher::return_type
 {
     if (end < begin)
     {
@@ -47,7 +47,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha512(T begin, T end) noexcept -> sha512_ha
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char* str) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const char* str) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -58,7 +58,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char* str) n
     return detail::sha512(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const char* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -68,7 +68,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char* str, b
     return detail::sha512(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const boost::crypt::uint8_t* str) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const boost::crypt::uint8_t* str) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -79,7 +79,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const boost::crypt
     return detail::sha512(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -89,7 +89,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const boost::crypt
     return detail::sha512(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char16_t* str) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const char16_t* str) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -100,7 +100,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char16_t* st
     return detail::sha512(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char16_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const char16_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -110,7 +110,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char16_t* st
     return detail::sha512(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char32_t* str) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const char32_t* str) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -121,7 +121,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char32_t* st
     return detail::sha512(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char32_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const char32_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -133,7 +133,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char32_t* st
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const wchar_t* str) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const wchar_t* str) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -144,7 +144,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const wchar_t* str
     return detail::sha512(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha512_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -180,22 +180,22 @@ BOOST_CRYPT_EXPORT inline auto sha512(const std::wstring& str) noexcept -> sha51
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha512(std::string_view str) -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512(std::string_view str) -> sha512_hasher::return_type
 {
     return detail::sha512(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512(std::u16string_view str) -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512(std::u16string_view str) -> sha512_hasher::return_type
 {
     return detail::sha512(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512(std::u32string_view str) -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512(std::u32string_view str) -> sha512_hasher::return_type
 {
     return detail::sha512(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512(std::wstring_view str) -> sha512_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512(std::wstring_view str) -> sha512_hasher::return_type
 {
     return detail::sha512(str.begin(), str.end());
 }
@@ -281,7 +281,7 @@ BOOST_CRYPT_EXPORT inline auto sha512_file(std::string_view filepath) noexcept -
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha512(std::span<T, extent> data) noexcept -> sha512_hasher::return_type
+constexpr auto sha512(std::span<T, extent> data) noexcept -> sha512_hasher::return_type
 {
     return detail::sha512(data.begin(), data.end());
 }
@@ -291,7 +291,7 @@ inline auto sha512(std::span<T, extent> data) noexcept -> sha512_hasher::return_
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(cuda::std::span<T, extent> data) noexcept -> sha512_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(cuda::std::span<T, extent> data) noexcept -> sha512_hasher::return_type
 {
     return detail::sha512(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha512_224.hpp
+++ b/include/boost/crypt/hash/sha512_224.hpp
@@ -18,7 +18,7 @@ BOOST_CRYPT_EXPORT using sha512_224_hasher = hash_detail::sha512_base<28U>;
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(T begin, T end) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(T begin, T end) noexcept -> sha512_224_hasher::return_type
 {
     if (end < begin)
     {
@@ -43,7 +43,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(T begin, T end) noexcept -> sha51
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char* str) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const char* str) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -54,7 +54,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char* st
     return detail::sha512_224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const char* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -64,7 +64,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char* st
     return detail::sha512_224(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const boost::crypt::uint8_t* str) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const boost::crypt::uint8_t* str) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -75,7 +75,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const boost::c
     return detail::sha512_224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -85,7 +85,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const boost::c
     return detail::sha512_224(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char16_t* str) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const char16_t* str) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -96,7 +96,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char16_t
     return detail::sha512_224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char16_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const char16_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -106,7 +106,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char16_t
     return detail::sha512_224(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char32_t* str) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const char32_t* str) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -117,7 +117,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char32_t
     return detail::sha512_224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char32_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const char32_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -129,7 +129,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const char32_t
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const wchar_t* str) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const wchar_t* str) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -140,7 +140,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const wchar_t*
     return detail::sha512_224(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha512_224_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -176,22 +176,22 @@ BOOST_CRYPT_EXPORT inline auto sha512_224(const std::wstring& str) noexcept -> s
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha512_224(std::string_view str) -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_224(std::string_view str) -> sha512_224_hasher::return_type
 {
     return detail::sha512_224(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512_224(std::u16string_view str) -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_224(std::u16string_view str) -> sha512_224_hasher::return_type
 {
     return detail::sha512_224(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512_224(std::u32string_view str) -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_224(std::u32string_view str) -> sha512_224_hasher::return_type
 {
     return detail::sha512_224(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512_224(std::wstring_view str) -> sha512_224_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_224(std::wstring_view str) -> sha512_224_hasher::return_type
 {
     return detail::sha512_224(str.begin(), str.end());
 }
@@ -277,7 +277,7 @@ BOOST_CRYPT_EXPORT inline auto sha512_224_file(std::string_view filepath) noexce
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha512_224(std::span<T, extent> data) noexcept -> sha512_224_hasher::return_type
+constexpr auto sha512_224(std::span<T, extent> data) noexcept -> sha512_224_hasher::return_type
 {
     return detail::sha512_224(data.begin(), data.end());
 }
@@ -287,7 +287,7 @@ inline auto sha512_224(std::span<T, extent> data) noexcept -> sha512_224_hasher:
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512_224(cuda::std::span<T, extent> data) noexcept -> sha512_224_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_224(cuda::std::span<T, extent> data) noexcept -> sha512_224_hasher::return_type
 {
     return detail::sha512_224(data.begin(), data.end());
 }

--- a/include/boost/crypt/hash/sha512_256.hpp
+++ b/include/boost/crypt/hash/sha512_256.hpp
@@ -18,7 +18,7 @@ BOOST_CRYPT_EXPORT using sha512_256_hasher = hash_detail::sha512_base<32U>;
 namespace detail {
 
 template <typename T>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(T begin, T end) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(T begin, T end) noexcept -> sha512_256_hasher::return_type
 {
     if (end < begin)
     {
@@ -43,7 +43,7 @@ BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(T begin, T end) noexcept -> sha51
 
 } // namespace detail
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char* str) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const char* str) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -54,7 +54,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char* st
     return detail::sha512_256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const char* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -64,7 +64,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char* st
     return detail::sha512_256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const boost::crypt::uint8_t* str) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const boost::crypt::uint8_t* str) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -75,7 +75,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const boost::c
     return detail::sha512_256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const boost::crypt::uint8_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -85,7 +85,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const boost::c
     return detail::sha512_256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char16_t* str) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const char16_t* str) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -96,7 +96,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char16_t
     return detail::sha512_256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char16_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const char16_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -106,7 +106,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char16_t
     return detail::sha512_256(str, str + len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char32_t* str) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const char32_t* str) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -117,7 +117,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char32_t
     return detail::sha512_256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char32_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const char32_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -129,7 +129,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const char32_t
 
 // On some platforms wchar_t is 16 bits and others it's 32
 // Since we check sizeof() the underlying with SFINAE in the actual implementation this is handled transparently
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const wchar_t* str) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const wchar_t* str) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -140,7 +140,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const wchar_t*
     return detail::sha512_256(str, str + message_len);
 }
 
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(const wchar_t* str, boost::crypt::size_t len) noexcept -> sha512_256_hasher::return_type
 {
     if (str == nullptr)
     {
@@ -176,22 +176,22 @@ BOOST_CRYPT_EXPORT inline auto sha512_256(const std::wstring& str) noexcept -> s
 
 #ifdef BOOST_CRYPT_HAS_STRING_VIEW
 
-BOOST_CRYPT_EXPORT inline auto sha512_256(std::string_view str) -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_256(std::string_view str) -> sha512_256_hasher::return_type
 {
     return detail::sha512_256(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512_256(std::u16string_view str) -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_256(std::u16string_view str) -> sha512_256_hasher::return_type
 {
     return detail::sha512_256(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512_256(std::u32string_view str) -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_256(std::u32string_view str) -> sha512_256_hasher::return_type
 {
     return detail::sha512_256(str.begin(), str.end());
 }
 
-BOOST_CRYPT_EXPORT inline auto sha512_256(std::wstring_view str) -> sha512_256_hasher::return_type
+BOOST_CRYPT_EXPORT constexpr auto sha512_256(std::wstring_view str) -> sha512_256_hasher::return_type
 {
     return detail::sha512_256(str.begin(), str.end());
 }
@@ -277,7 +277,7 @@ BOOST_CRYPT_EXPORT inline auto sha512_256_file(std::string_view filepath) noexce
 #ifdef BOOST_CRYPT_HAS_SPAN
 
 BOOST_CRYPT_EXPORT template <typename T, std::size_t extent>
-inline auto sha512_256(std::span<T, extent> data) noexcept -> sha512_256_hasher::return_type
+constexpr auto sha512_256(std::span<T, extent> data) noexcept -> sha512_256_hasher::return_type
 {
     return detail::sha512_256(data.begin(), data.end());
 }
@@ -287,7 +287,7 @@ inline auto sha512_256(std::span<T, extent> data) noexcept -> sha512_256_hasher:
 #ifdef BOOST_CRYPT_HAS_CUDA
 
 template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto sha512_256(cuda::std::span<T, extent> data) noexcept -> sha512_256_hasher::return_type
+BOOST_CRYPT_GPU_ENABLED constexpr auto sha512_256(cuda::std::span<T, extent> data) noexcept -> sha512_256_hasher::return_type
 {
     return detail::sha512_256(data.begin(), data.end());
 }


### PR DESCRIPTION
We can workaround the need for virtual functions by employing CRTP at the C++14 level

Closes: #58 