### PR TITLE
Use expected as the return type

### DIFF
--- a/doc/crypt.adoc
+++ b/doc/crypt.adoc
@@ -25,13 +25,12 @@ include::crypt/sha1.adoc[]
 
 include::crypt/sha224.adoc[]
 
-////
 include::crypt/sha256.adoc[]
 
-include::crypt/sha384.adoc[]
+#include::crypt/sha384.adoc[]
 
 include::crypt/sha512.adoc[]
-
+////
 include::crypt/sha512_224.adoc[]
 
 include::crypt/sha512_256.adoc[]

--- a/doc/crypt/api_reference.adoc
+++ b/doc/crypt/api_reference.adoc
@@ -14,7 +14,7 @@ https://www.boost.org/LICENSE_1_0.txt
 
 == Types
 
-- `boost::crypt::expected` - either https://tl.tartanllama.xyz/en/latest/api/expected.html[`tl::expected`] or `cuda::std::expected` depending on context.
+- `boost::crypt::expected` - either an alias to https://tl.tartanllama.xyz/en/latest/api/expected.html[`tl::expected`] or `cuda::std::expected` depending on context.
 
 == Structures and Classes
 

--- a/doc/crypt/api_reference.adoc
+++ b/doc/crypt/api_reference.adoc
@@ -14,12 +14,13 @@ https://www.boost.org/LICENSE_1_0.txt
 
 == Types
 
-- None
+- `boost::crypt::expected` - either https://tl.tartanllama.xyz/en/latest/api/expected.html[`tl::expected`] or `cuda::std::expected` depending on context.
 
 == Structures and Classes
 
 === Hashers
 
+==== SHA1
 - <<sha1_hasher, `sha1_hasher`>>
 
 ==== SHA2 Family of Hashers

--- a/doc/crypt/sha1.adoc
+++ b/doc/crypt/sha1.adoc
@@ -28,22 +28,24 @@ public:
     uisng return_type = compat::array<compat::byte, 20>;
 
     // Initialize the hasher
-    constexpr void init() noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr void init() noexcept;
 
     // Process bytes piecewise
-    constexpr state process_bytes(compat::span<const compat::byte> data) noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(compat::span<const compat::byte> data) noexcept;
 
     template <compat::ranges::sized_range Range>
-    constexpr state process_bytes(Range&& data) noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(Range&& data) noexcept;
 
     // Finalize the calculation of the hash
-    constexpr state finalize() noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr state finalize() noexcept;
 
     // Get the digest
-    [[nodiscard]] constexpr return_type get_digest() noexcept;
+    [[nodiscard]] constexpr expected<return_type, state> get_digest() const noexcept;
+
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR state get_digest(compat::span<compat::byte> data) const noexcept;
 
     template <concepts::writable_output_range Range>
-    BOOST_CRYPT_GPU_ENABLED state get_digest(Range&& data) noexcept
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED state get_digest(Range&& data) const noexcept;
 };
 
 } // namespace boost::crypt
@@ -55,10 +57,10 @@ public:
 ----
 namespace boost::crypt {
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(compat::span<const compat::byte> data) noexcept -> sha1_hasher::return_type;
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(compat::span<const compat::byte> data) noexcept -> expected<sha1_hasher::return_type, state>;
 
 template <compat::ranges::sized_range SizedRange>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha1(SizedRange&& data) noexcept -> sha1_hasher::return_type;
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED auto sha1(SizedRange&& data) noexcept -> expected<sha1_hasher::return_type, state>;
 
 } // namespace boost::crypt
 ----
@@ -72,7 +74,7 @@ We also have the ability to scan files and return the sha1 value:
 namespace boost::crypt {
 
 template <concepts::file_system_path T>
-inline auto sha1_file(const T& filepath) -> sha1_hasher::return_type;
+[[nodiscard]] inline auto sha1_file(const T& filepath) -> expected<sha1_hasher::return_type, state>;
 
 } // namespace boost::crypt
 ----

--- a/doc/crypt/sha224.adoc
+++ b/doc/crypt/sha224.adoc
@@ -20,7 +20,7 @@ This class does not use any dynamic memory allocation.
 
 [source, c++]
 ----
-namespace boost::crypt
+namespace boost::crypt {
 
 class sha224_hasher
 {
@@ -28,22 +28,24 @@ public:
     uisng return_type = compat::array<compat::byte, 28>;
 
     // Initialize the hasher
-    constexpr void init() noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr void init() noexcept;
 
     // Process bytes piecewise
-    constexpr state process_bytes(compat::span<const compat::byte> data) noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(compat::span<const compat::byte> data) noexcept;
 
     template <compat::ranges::sized_range Range>
-    constexpr state process_bytes(Range&& data) noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(Range&& data) noexcept;
 
     // Finalize the calculation of the hash
-    constexpr state finalize() noexcept;
+    BOOST_CRYPT_GPU_ENABLED constexpr state finalize() noexcept;
 
     // Get the digest
-    [[nodiscard]] constexpr return_type get_digest() noexcept;
+    [[nodiscard]] constexpr expected<return_type, state> get_digest() const noexcept;
+
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR state get_digest(compat::span<compat::byte> data) const noexcept;
 
     template <concepts::writable_output_range Range>
-    BOOST_CRYPT_GPU_ENABLED state get_digest(Range&& data) noexcept
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED state get_digest(Range&& data) const noexcept;
 };
 
 } // namespace boost::crypt
@@ -55,10 +57,10 @@ public:
 ----
 namespace boost::crypt {
 
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(compat::span<const compat::byte> data) noexcept -> sha224_hasher::return_type;
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(compat::span<const compat::byte> data) noexcept -> expected<sha224_hasher::return_type, state>;
 
 template <compat::ranges::sized_range SizedRange>
-BOOST_CRYPT_GPU_ENABLED constexpr auto sha224(SizedRange&& data) noexcept -> sha224_hasher::return_type;
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED auto sha224(SizedRange&& data) noexcept -> expected<sha224_hasher::return_type, state>;
 
 } // namespace boost::crypt
 ----
@@ -72,7 +74,7 @@ We also have the ability to scan files and return the sha224 value:
 namespace boost::crypt {
 
 template <concepts::file_system_path T>
-inline auto sha224_file(const T& filepath) -> sha224_hasher::return_type;
+[[nodiscard]] inline auto sha224_file(const T& filepath) -> expected<sha224_hasher::return_type, state>;
 
 } // namespace boost::crypt
 ----

--- a/doc/crypt/sha256.adoc
+++ b/doc/crypt/sha256.adoc
@@ -25,7 +25,7 @@ namespace boost::crypt {
 class sha256_hasher
 {
 public:
-    uisng return_type = compat::array<compat::byte, 28>;
+    uisng return_type = compat::array<compat::byte, 32>;
 
     // Initialize the hasher
     BOOST_CRYPT_GPU_ENABLED constexpr void init() noexcept;

--- a/doc/crypt/sha256.adoc
+++ b/doc/crypt/sha256.adoc
@@ -12,94 +12,6 @@ https://www.boost.org/LICENSE_1_0.txt
 This library supports sha256 as described in https://datatracker.ietf.org/doc/html/rfc6234[RFC 6234].
 There is a wide range of acceptable inputs for the base sha256 function:
 
-== Hashing Functions
-
-[source, c++]
-----
-namespace boost {
-namespace crypt {
-
-uisng return_type = boost::crypt::array<uint8_t, 32>;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const unsigned char* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const unsigned char* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char16_t* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const char32_t* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha256(const wchar_t* str, size_t len) noexcept -> return_type;
-
-inline auto sha256(const std::string& str) noexcept -> return_type;
-
-inline auto sha256(const std::u16string& str) noexcept -> return_type;
-
-inline auto sha256(const std::u32string& str) noexcept -> return_type;
-
-inline auto sha256(const std::wstring& str) noexcept -> return_type;
-
-#ifdef BOOST_CRYPT_HAS_STRING_VIEW
-
-inline auto sha256(std::string_view str) noexcept -> return_type;
-
-inline auto sha256(std::u16string_view str) noexcept -> return_type;
-
-inline auto sha256(std::u32string_view str) noexcept -> return_type;
-
-inline auto sha256(std::wstring_view str) noexcept -> return_type;
-
-#endif // BOOST_CRYPT_HAS_STRING_VIEW
-
-#ifdef BOOST_CRYPT_HAS_SPAN
-
-template <typename T, std::size_t extent>
-inline auto md5(std::span<T, extent> data) noexcept -> return_type;
-
-#endif // BOOST_CRYPT_HAS_SPAN
-
-#ifdef BOOST_CRYPT_HAS_CUDA
-
-template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
-
-#endif // BOOST_CRYPT_HAS_CUDA
-
-} //namespace crypt
-} //namespace boost
-----
-
-== File Hashing Functions
-
-We also have the ability to scan files and return the sha256 value:
-
-[source, c++]
-----
-namespace boost {
-namespace crypt {
-
-uisng return_type = boost::crypt::array<uint8_t, 32>;
-
-inline auto sha256_file(const char* filepath) noexcept -> return_type;
-
-inline auto sha256_file(const std::string& filepath) noexcept -> return_type;
-
-inline auto sha256_file(std::string_view filepath) noexcept -> return_type;
-
-} // namespace crypt
-} // namespace boost
-----
-
 == Hashing Object
 
 [#sha256_hasher]
@@ -108,50 +20,61 @@ This class does not use any dynamic memory allocation.
 
 [source, c++]
 ----
-namespace boost {
-namespace crypt {
+namespace boost::crypt {
 
 class sha256_hasher
 {
-    uisng return_type = boost::crypt::array<uint8_t, 32>;
+public:
+    uisng return_type = compat::array<compat::byte, 28>;
 
-    void init();
+    // Initialize the hasher
+    BOOST_CRYPT_GPU_ENABLED constexpr void init() noexcept;
 
-    template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> state;
+    // Process bytes piecewise
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(compat::span<const compat::byte> data) noexcept;
 
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> state;
+    template <compat::ranges::sized_range Range>
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(Range&& data) noexcept;
 
-    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+    // Finalize the calculation of the hash
+    BOOST_CRYPT_GPU_ENABLED constexpr state finalize() noexcept;
 
-    inline auto process_bytes(std::string_view str) noexcept -> state;
+    // Get the digest
+    [[nodiscard]] constexpr expected<return_type, state> get_digest() const noexcept;
 
-    inline auto process_bytes(std::u16string_view str) noexcept -> state;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR state get_digest(compat::span<compat::byte> data) const noexcept;
 
-    inline auto process_bytes(std::u32string_view str) noexcept -> state;
-
-    inline auto process_bytes(std::wstring_view str) noexcept -> state;
-
-    #endif // BOOST_CRYPT_HAS_STRING_VIEW
-
-    #ifdef BOOST_CRYPT_HAS_SPAN
-
-    template <typename T, boost::crypt::size_t extent>
-    inline auto process_bytes(std::span<T, extent> data) noexcept -> state;
-
-    #endif // BOOST_CRYPT_HAS_SPAN
-
-    #ifdef BOOST_CRYPT_HAS_CUDA
-
-    template <typename T, boost::crypt::size_t extent>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> state;
-
-    #endif // BOOST_CRYPT_HAS_CUDA
-
-    inline auto get_digest() noexcept -> return_type;
+    template <concepts::writable_output_range Range>
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED state get_digest(Range&& data) const noexcept;
 };
 
-} // namespace crypt
-} // namespace boost
+} // namespace boost::crypt
+----
+
+== One-Shot Hashing Functions
+
+[source, c++]
+----
+namespace boost::crypt {
+
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED constexpr auto sha256(compat::span<const compat::byte> data) noexcept -> expected<sha256_hasher::return_type, state>;
+
+template <compat::ranges::sized_range SizedRange>
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED auto sha256(SizedRange&& data) noexcept -> expected<sha256_hasher::return_type, state>;
+
+} // namespace boost::crypt
+----
+
+== File Hashing Functions
+
+We also have the ability to scan files and return the sha256 value:
+
+[source, c++]
+----
+namespace boost::crypt {
+
+template <concepts::file_system_path T>
+[[nodiscard]] inline auto sha256_file(const T& filepath) -> expected<sha256_hasher::return_type, state>;
+
+} // namespace boost::crypt
 ----

--- a/doc/crypt/sha512.adoc
+++ b/doc/crypt/sha512.adoc
@@ -12,94 +12,6 @@ https://www.boost.org/LICENSE_1_0.txt
 This library supports sha512 as described in https://datatracker.ietf.org/doc/html/rfc6234[RFC 6234].
 There is a wide range of acceptable inputs for the base sha512 function:
 
-== Hashing Functions
-
-[source, c++]
-----
-namespace boost {
-namespace crypt {
-
-uisng return_type = boost::crypt::array<uint8_t, 64>;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const unsigned char* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const unsigned char* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char16_t* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char16_t* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char32_t* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const char32_t* str, size_t len) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const wchar_t* str) noexcept -> return_type;
-
-BOOST_CRYPT_GPU_ENABLED inline auto sha512(const wchar_t* str, size_t len) noexcept -> return_type;
-
-inline auto sha512(const std::string& str) noexcept -> return_type;
-
-inline auto sha512(const std::u16string& str) noexcept -> return_type;
-
-inline auto sha512(const std::u32string& str) noexcept -> return_type;
-
-inline auto sha512(const std::wstring& str) noexcept -> return_type;
-
-#ifdef BOOST_CRYPT_HAS_STRING_VIEW
-
-inline auto sha512(std::string_view str) noexcept -> return_type;
-
-inline auto sha512(std::u16string_view str) noexcept -> return_type;
-
-inline auto sha512(std::u32string_view str) noexcept -> return_type;
-
-inline auto sha512(std::wstring_view str) noexcept -> return_type;
-
-#endif // BOOST_CRYPT_HAS_STRING_VIEW
-
-#ifdef BOOST_CRYPT_HAS_SPAN
-
-template <typename T, std::size_t extent>
-inline auto md5(std::span<T, extent> data) noexcept -> return_type;
-
-#endif // BOOST_CRYPT_HAS_SPAN
-
-#ifdef BOOST_CRYPT_HAS_CUDA
-
-template <typename T, boost::crypt::size_t extent>
-BOOST_CRYPT_GPU_ENABLED inline auto md5(cuda::std::span<T, extent> data) noexcept -> return_type;
-
-#endif // BOOST_CRYPT_HAS_CUDA
-
-} //namespace crypt
-} //namespace boost
-----
-
-== File Hashing Functions
-
-We also have the ability to scan files and return the sha512 value:
-
-[source, c++]
-----
-namespace boost {
-namespace crypt {
-
-uisng return_type = boost::crypt::array<uint8_t, 64>;
-
-inline auto sha512_file(const char* filepath) noexcept -> return_type;
-
-inline auto sha512_file(const std::string& filepath) noexcept -> return_type;
-
-inline auto sha512_file(std::string_view filepath) noexcept -> return_type;
-
-} // namespace crypt
-} // namespace boost
-----
-
 == Hashing Object
 
 [#sha512_hasher]
@@ -108,50 +20,61 @@ This class does not use any dynamic memory allocation.
 
 [source, c++]
 ----
-namespace boost {
-namespace crypt {
+namespace boost::crypt {
 
 class sha512_hasher
 {
-    uisng return_type = boost::crypt::array<uint8_t, 64>;
+public:
+    uisng return_type = compat::array<compat::byte, 64>;
 
-    void init();
+    // Initialize the hasher
+    BOOST_CRYPT_GPU_ENABLED constexpr void init() noexcept;
 
-    template <typename ByteType>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_byte(ByteType byte) noexcept -> state;
+    // Process bytes piecewise
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(compat::span<const compat::byte> data) noexcept;
 
-    template <typename ForwardIter>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(ForwardIter buffer, size_t byte_count) noexcept -> state;
+    template <compat::ranges::sized_range Range>
+    BOOST_CRYPT_GPU_ENABLED constexpr state process_bytes(Range&& data) noexcept;
 
-    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
+    // Finalize the calculation of the hash
+    BOOST_CRYPT_GPU_ENABLED constexpr state finalize() noexcept;
 
-    inline auto process_bytes(std::string_view str) noexcept -> state;
+    // Get the digest
+    [[nodiscard]] constexpr expected<return_type, state> get_digest() const noexcept;
 
-    inline auto process_bytes(std::u16string_view str) noexcept -> state;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR state get_digest(compat::span<compat::byte> data) const noexcept;
 
-    inline auto process_bytes(std::u32string_view str) noexcept -> state;
-
-    inline auto process_bytes(std::wstring_view str) noexcept -> state;
-
-    #endif // BOOST_CRYPT_HAS_STRING_VIEW
-
-    #ifdef BOOST_CRYPT_HAS_SPAN
-
-    template <typename T, boost::crypt::size_t extent>
-    inline auto process_bytes(std::span<T, extent> data) noexcept -> state;
-
-    #endif // BOOST_CRYPT_HAS_SPAN
-
-    #ifdef BOOST_CRYPT_HAS_CUDA
-
-    template <typename T, boost::crypt::size_t extent>
-    BOOST_CRYPT_GPU_ENABLED inline auto process_bytes(cuda::std::span<T, extent> data) noexcept -> state;
-
-    #endif // BOOST_CRYPT_HAS_CUDA
-
-    inline auto get_digest() noexcept -> return_type;
+    template <concepts::writable_output_range Range>
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED state get_digest(Range&& data) const noexcept;
 };
 
-} // namespace crypt
-} // namespace boost
+} // namespace boost::crypt
+----
+
+== One-Shot Hashing Functions
+
+[source, c++]
+----
+namespace boost::crypt {
+
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED constexpr auto sha512(compat::span<const compat::byte> data) noexcept -> expected<sha512_hasher::return_type, state>;
+
+template <compat::ranges::sized_range SizedRange>
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED auto sha512(SizedRange&& data) noexcept -> expected<sha512_hasher::return_type, state>;
+
+} // namespace boost::crypt
+----
+
+== File Hashing Functions
+
+We also have the ability to scan files and return the sha512 value:
+
+[source, c++]
+----
+namespace boost::crypt {
+
+template <concepts::file_system_path T>
+[[nodiscard]] inline auto sha512_file(const T& filepath) -> expected<sha512_hasher::return_type, state>;
+
+} // namespace boost::crypt
 ----

--- a/include/boost/crypt2/detail/compat.hpp
+++ b/include/boost/crypt2/detail/compat.hpp
@@ -10,6 +10,10 @@
 
 #include <boost/crypt2/detail/config.hpp>
 
+#if !defined(BOOST_CRYPT_HAS_CUDA)
+#include <boost/crypt2/detail/expected.hpp>
+#endif
+
 #if !defined(BOOST_CRYPT_BUILD_MODULE) && !defined(BOOST_CRYPT_HAS_CUDA)
 
 #include <span>
@@ -33,6 +37,7 @@
 #include <cuda/std/ranges>
 #include <cuda/std/utility>
 #include <cuda/std/bit>
+#include <cuda/std/expected>
 
 #endif
 
@@ -273,6 +278,23 @@ BOOST_CRYPT_GPU_ENABLED constexpr auto rotr(T val, int shift) noexcept
     #pragma clang diagnostic pop
     #endif
 }
+
+// Expected
+template <typename T, typename E>
+using expected =
+        #ifdef BOOST_CRYPT_HAS_CUDA
+        cuda::std::expected<T, E>;
+        #else
+        boost::crypt::detail::expected_impl::expected<T, E>;
+        #endif
+
+template <typename E>
+using unexpected =
+        #ifdef BOOST_CRYPT_HAS_CUDA
+        cuda::std::unexpected<E>;
+        #else
+        boost::crypt::detail::expected_impl::unexpected<E>;
+        #endif
 
 } // namespace boost::crypt::compat
 

--- a/include/boost/crypt2/detail/expected.hpp
+++ b/include/boost/crypt2/detail/expected.hpp
@@ -1,0 +1,2447 @@
+///
+// expected - An implementation of std::expected with extensions
+// Written in 2017 by Sy Brand (tartanllama@gmail.com, @TartanLlama)
+//
+// Documentation available at http://tl.tartanllama.xyz/
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to the
+// public domain worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software. If not, see
+// <http://creativecommons.org/publicdomain/zero/1.0/>.
+///
+//
+// Adaptations for boost.crypt Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_HPP
+#define BOOST_CRYPT_TL_EXPECTED_HPP
+
+// LCOV_EXCL_START
+
+#define BOOST_CRYPT_TL_EXPECTED_VERSION_MAJOR 1
+#define BOOST_CRYPT_TL_EXPECTED_VERSION_MINOR 1
+#define BOOST_CRYPT_TL_EXPECTED_VERSION_PATCH 0
+
+#include <boost/crypt2/detail/assert.hpp>
+
+#if !defined(BOOST_CRYPT_BUILD_MODULE)
+#include <exception>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#endif
+
+#if defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#define BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+#endif
+
+#if (defined(_MSC_VER) && _MSC_VER == 1900)
+#define BOOST_CRYPT_TL_EXPECTED_MSVC2015
+#define BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR
+#else
+#define BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR constexpr
+#endif
+
+#if (defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 &&              \
+     !defined(__clang__))
+#define BOOST_CRYPT_TL_EXPECTED_GCC49
+#endif
+
+#if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 4 &&              \
+     !defined(__clang__))
+#define BOOST_CRYPT_TL_EXPECTED_GCC54
+#endif
+
+#if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 5 &&              \
+     !defined(__clang__))
+#define BOOST_CRYPT_TL_EXPECTED_GCC55
+#endif
+
+#if (defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 &&              \
+     !defined(__clang__))
+// GCC < 5 doesn't support overloading on const&& for member functions
+
+#define BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+// GCC < 5 doesn't support some standard C++11 type traits
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)                         \
+  std::has_trivial_copy_constructor<T>
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T)                            \
+  std::has_trivial_copy_assign<T>
+
+// This one will be different for GCC 5.7 if it's ever supported
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)                               \
+  std::is_trivially_destructible<T>
+
+// GCC 5 < v < 8 has a bug in is_trivially_copy_constructible which breaks
+// std::vector for non-copyable types
+#elif (defined(__GNUC__) && __GNUC__ < 8 && !defined(__clang__))
+#ifndef TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
+#define BOOST_CRYPT_TL_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
+namespace boost::crypt::detail::expected_impl {
+namespace detail {
+template <class T>
+struct is_trivially_copy_constructible
+    : std::is_trivially_copy_constructible<T> {};
+#ifdef _GLIBCXX_VECTOR
+template <class T, class A>
+struct is_trivially_copy_constructible<std::vector<T, A>> : std::false_type {};
+#endif
+} // namespace detail
+} // namespace tl
+#endif
+
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)                         \
+  tl::detail::is_trivially_copy_constructible<T>
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T)                            \
+  std::is_trivially_copy_assignable<T>
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)                               \
+  std::is_trivially_destructible<T>
+#else
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)                         \
+  std::is_trivially_copy_constructible<T>
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T)                            \
+  std::is_trivially_copy_assignable<T>
+#define BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)                               \
+  std::is_trivially_destructible<T>
+#endif
+
+#if __cplusplus > 201103L
+#define BOOST_CRYPT_TL_EXPECTED_CXX14
+#endif
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_GCC49
+#define BOOST_CRYPT_TL_EXPECTED_GCC49_CONSTEXPR
+#else
+#define BOOST_CRYPT_TL_EXPECTED_GCC49_CONSTEXPR constexpr
+#endif
+
+#if (__cplusplus == 201103L || defined(BOOST_CRYPT_TL_EXPECTED_MSVC2015) ||                \
+     defined(BOOST_CRYPT_TL_EXPECTED_GCC49))
+#define BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR
+#else
+#define BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR constexpr
+#endif
+
+namespace boost::crypt::detail::expected_impl {
+template <class T, class E> class expected;
+
+#ifndef TL_MONOSTATE_INPLACE_MUTEX
+#define BOOST_CRYPT_TL_MONOSTATE_INPLACE_MUTEX
+class monostate {};
+
+struct in_place_t {
+    explicit in_place_t() = default;
+};
+static constexpr in_place_t in_place{};
+#endif
+
+template <class E> class unexpected {
+public:
+    static_assert(!std::is_same<E, void>::value, "E must not be void");
+
+    unexpected() = delete;
+    constexpr explicit unexpected(const E &e) : m_val(e) {}
+
+    constexpr explicit unexpected(E &&e) : m_val(std::move(e)) {}
+
+    template <class... Args, typename std::enable_if<std::is_constructible<
+            E, Args &&...>::value>::type * = nullptr>
+    constexpr explicit unexpected(Args &&...args)
+            : m_val(std::forward<Args>(args)...) {}
+    template <
+            class U, class... Args,
+            typename std::enable_if<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value>::type * = nullptr>
+    constexpr explicit unexpected(std::initializer_list<U> l, Args &&...args)
+            : m_val(l, std::forward<Args>(args)...) {}
+
+    constexpr const E &value() const & { return m_val; }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR E &value() & { return m_val; }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR E &&value() && { return std::move(m_val); }
+    constexpr const E &&value() const && { return std::move(m_val); }
+
+private:
+    E m_val;
+};
+
+#ifdef __cpp_deduction_guides
+template <class E> unexpected(E) -> unexpected<E>;
+#endif
+
+template <class E>
+constexpr bool operator==(const unexpected<E> &lhs, const unexpected<E> &rhs) {
+    return lhs.value() == rhs.value();
+}
+template <class E>
+constexpr bool operator!=(const unexpected<E> &lhs, const unexpected<E> &rhs) {
+    return lhs.value() != rhs.value();
+}
+template <class E>
+constexpr bool operator<(const unexpected<E> &lhs, const unexpected<E> &rhs) {
+    return lhs.value() < rhs.value();
+}
+template <class E>
+constexpr bool operator<=(const unexpected<E> &lhs, const unexpected<E> &rhs) {
+    return lhs.value() <= rhs.value();
+}
+template <class E>
+constexpr bool operator>(const unexpected<E> &lhs, const unexpected<E> &rhs) {
+    return lhs.value() > rhs.value();
+}
+template <class E>
+constexpr bool operator>=(const unexpected<E> &lhs, const unexpected<E> &rhs) {
+    return lhs.value() >= rhs.value();
+}
+
+template <class E>
+unexpected<typename std::decay<E>::type> make_unexpected(E &&e) {
+    return unexpected<typename std::decay<E>::type>(std::forward<E>(e));
+}
+
+struct unexpect_t {
+    unexpect_t() = default;
+};
+static constexpr unexpect_t unexpect{};
+
+namespace detail {
+template <typename E>
+[[noreturn]] BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR void throw_exception(E &&e) {
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+    throw std::forward<E>(e);
+#else
+    (void)e;
+#ifdef _MSC_VER
+  __assume(0);
+#else
+  __builtin_unreachable();
+#endif
+#endif
+}
+
+#ifndef TL_TRAITS_MUTEX
+#define BOOST_CRYPT_TL_TRAITS_MUTEX
+// C++14-style aliases for brevity
+template <class T> using remove_const_t = typename std::remove_const<T>::type;
+template <class T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+template <class T> using decay_t = typename std::decay<T>::type;
+template <bool E, class T = void>
+using enable_if_t = typename std::enable_if<E, T>::type;
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+
+// std::conjunction from C++17
+template <class...> struct conjunction : std::true_type {};
+template <class B> struct conjunction<B> : B {};
+template <class B, class... Bs>
+struct conjunction<B, Bs...>
+        : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
+
+#if defined(_LIBCPP_VERSION) && __cplusplus == 201103L
+#define BOOST_CRYPT_TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+#endif
+
+// In C++11 mode, there's an issue in libc++'s std::mem_fn
+// which results in a hard-error when using it in a noexcept expression
+// in some cases. This is a check to workaround the common failing case.
+#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+template <class T>
+struct is_pointer_to_non_const_member_func : std::false_type {};
+template <class T, class Ret, class... Args>
+struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...)>
+    : std::true_type {};
+template <class T, class Ret, class... Args>
+struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) &>
+    : std::true_type {};
+template <class T, class Ret, class... Args>
+struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) &&>
+    : std::true_type {};
+template <class T, class Ret, class... Args>
+struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile>
+    : std::true_type {};
+template <class T, class Ret, class... Args>
+struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile &>
+    : std::true_type {};
+template <class T, class Ret, class... Args>
+struct is_pointer_to_non_const_member_func<Ret (T::*)(Args...) volatile &&>
+    : std::true_type {};
+
+template <class T> struct is_const_or_const_ref : std::false_type {};
+template <class T> struct is_const_or_const_ref<T const &> : std::true_type {};
+template <class T> struct is_const_or_const_ref<T const> : std::true_type {};
+#endif
+
+// std::invoke from C++17
+// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
+template <
+        typename Fn, typename... Args,
+#ifdef TL_TRAITS_LIBCXX_MEM_FN_WORKAROUND
+        typename = enable_if_t<!(is_pointer_to_non_const_member_func<Fn>::value &&
+                             is_const_or_const_ref<Args...>::value)>,
+#endif
+        typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>::value>, int = 0>
+constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
+noexcept(std::mem_fn(f)(std::forward<Args>(args)...)))
+-> decltype(std::mem_fn(f)(std::forward<Args>(args)...)) {
+    return std::mem_fn(f)(std::forward<Args>(args)...);
+}
+
+template <typename Fn, typename... Args,
+        typename = enable_if_t<!std::is_member_pointer<decay_t<Fn>>::value>>
+constexpr auto invoke(Fn &&f, Args &&...args) noexcept(
+noexcept(std::forward<Fn>(f)(std::forward<Args>(args)...)))
+-> decltype(std::forward<Fn>(f)(std::forward<Args>(args)...)) {
+    return std::forward<Fn>(f)(std::forward<Args>(args)...);
+}
+
+// std::invoke_result from C++17
+template <class F, class, class... Us> struct invoke_result_impl;
+
+template <class F, class... Us>
+struct invoke_result_impl<
+        F,
+        decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...), void()),
+        Us...> {
+    using type =
+            decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...));
+};
+
+template <class F, class... Us>
+using invoke_result = invoke_result_impl<F, void, Us...>;
+
+template <class F, class... Us>
+using invoke_result_t = typename invoke_result<F, Us...>::type;
+
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+// TODO make a version which works with MSVC 2015
+template <class T, class U = T> struct is_swappable : std::true_type {};
+
+template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
+#else
+// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
+namespace swap_adl_tests {
+// if swap ADL finds this then it would call std::swap otherwise (same
+// signature)
+struct tag {};
+
+template <class T> tag swap(T &, T &);
+template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
+
+// helper functions to test if an unqualified swap is possible, and if it
+// becomes std::swap
+template <class, class> std::false_type can_swap(...) noexcept(false);
+template <class T, class U,
+        class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
+std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
+                                                    std::declval<U &>())));
+
+template <class, class> std::false_type uses_std(...);
+template <class T, class U>
+std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
+uses_std(int);
+
+template <class T>
+struct is_std_swap_noexcept
+        : std::integral_constant<bool,
+                std::is_nothrow_move_constructible<T>::value &&
+                std::is_nothrow_move_assignable<T>::value> {};
+
+template <class T, std::size_t N>
+struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
+
+template <class T, class U>
+struct is_adl_swap_noexcept
+        : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
+} // namespace swap_adl_tests
+
+template <class T, class U = T>
+struct is_swappable
+        : std::integral_constant<
+                bool,
+                decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
+                (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
+                 (std::is_move_assignable<T>::value &&
+                  std::is_move_constructible<T>::value))> {};
+
+template <class T, std::size_t N>
+struct is_swappable<T[N], T[N]>
+        : std::integral_constant<
+                bool,
+                decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
+                (!decltype(detail::swap_adl_tests::uses_std<T[N], T[N]>(
+                        0))::value ||
+                 is_swappable<T, T>::value)> {};
+
+template <class T, class U = T>
+struct is_nothrow_swappable
+        : std::integral_constant<
+                bool,
+                is_swappable<T, U>::value &&
+                ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
+                  detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
+                 (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
+                  detail::swap_adl_tests::is_adl_swap_noexcept<T, U>::value))> {};
+#endif
+#endif
+
+// Trait for checking if a type is a tl::expected
+template <class T> struct is_expected_impl : std::false_type {};
+template <class T, class E>
+struct is_expected_impl<expected<T, E>> : std::true_type {};
+template <class T> using is_expected = is_expected_impl<decay_t<T>>;
+
+template <class T, class E, class U>
+using expected_enable_forward_value = detail::enable_if_t<
+        std::is_constructible<T, U &&>::value &&
+        !std::is_same<detail::decay_t<U>, in_place_t>::value &&
+        !std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
+        !std::is_same<unexpected<E>, detail::decay_t<U>>::value>;
+
+template <class T, class E, class U, class G, class UR, class GR>
+using expected_enable_from_other = detail::enable_if_t<
+        std::is_constructible<T, UR>::value &&
+        std::is_constructible<E, GR>::value &&
+        !std::is_constructible<T, expected<U, G> &>::value &&
+        !std::is_constructible<T, expected<U, G> &&>::value &&
+        !std::is_constructible<T, const expected<U, G> &>::value &&
+        !std::is_constructible<T, const expected<U, G> &&>::value &&
+        !std::is_convertible<expected<U, G> &, T>::value &&
+        !std::is_convertible<expected<U, G> &&, T>::value &&
+        !std::is_convertible<const expected<U, G> &, T>::value &&
+        !std::is_convertible<const expected<U, G> &&, T>::value>;
+
+template <class T, class U>
+using is_void_or = conditional_t<std::is_void<T>::value, std::true_type, U>;
+
+template <class T>
+using is_copy_constructible_or_void =
+        is_void_or<T, std::is_copy_constructible<T>>;
+
+template <class T>
+using is_move_constructible_or_void =
+        is_void_or<T, std::is_move_constructible<T>>;
+
+template <class T>
+using is_copy_assignable_or_void = is_void_or<T, std::is_copy_assignable<T>>;
+
+template <class T>
+using is_move_assignable_or_void = is_void_or<T, std::is_move_assignable<T>>;
+
+} // namespace detail
+
+namespace detail {
+struct no_init_t {};
+static constexpr no_init_t no_init{};
+
+// Implements the storage of the values, and ensures that the destructor is
+// trivial if it can be.
+//
+// This specialization is for where neither `T` or `E` is trivially
+// destructible, so the destructors must be called on destruction of the
+// `expected`
+template <class T, class E, bool = std::is_trivially_destructible<T>::value,
+        bool = std::is_trivially_destructible<E>::value>
+struct expected_storage_base {
+    constexpr expected_storage_base() : m_val(T{}), m_has_val(true) {}
+    constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            nullptr>
+    constexpr expected_storage_base(in_place_t, Args &&...args)
+            : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                    Args &&...args)
+            : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+            : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected_storage_base(unexpect_t,
+                                             std::initializer_list<U> il,
+                                             Args &&...args)
+            : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
+
+    ~expected_storage_base() {
+        if (m_has_val) {
+            m_val.~T();
+        } else {
+            m_unexpect.~unexpected<E>();
+        }
+    }
+    union {
+        T m_val;
+        unexpected<E> m_unexpect;
+        char m_no_init;
+    };
+    bool m_has_val;
+};
+
+// This specialization is for when both `T` and `E` are trivially-destructible,
+// so the destructor of the `expected` can be trivial.
+template <class T, class E> struct expected_storage_base<T, E, true, true> {
+    constexpr expected_storage_base() : m_val(T{}), m_has_val(true) {}
+    constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            nullptr>
+    constexpr expected_storage_base(in_place_t, Args &&...args)
+            : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                    Args &&...args)
+            : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+            : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected_storage_base(unexpect_t,
+                                             std::initializer_list<U> il,
+                                             Args &&...args)
+            : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
+
+    ~expected_storage_base() = default;
+    union {
+        T m_val;
+        unexpected<E> m_unexpect;
+        char m_no_init;
+    };
+    bool m_has_val;
+};
+
+// T is trivial, E is not.
+template <class T, class E> struct expected_storage_base<T, E, true, false> {
+    constexpr expected_storage_base() : m_val(T{}), m_has_val(true) {}
+    BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR expected_storage_base(no_init_t)
+            : m_no_init(), m_has_val(false) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            nullptr>
+    constexpr expected_storage_base(in_place_t, Args &&...args)
+            : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                    Args &&...args)
+            : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+            : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected_storage_base(unexpect_t,
+                                             std::initializer_list<U> il,
+                                             Args &&...args)
+            : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
+
+    ~expected_storage_base() {
+        if (!m_has_val) {
+            m_unexpect.~unexpected<E>();
+        }
+    }
+
+    union {
+        T m_val;
+        unexpected<E> m_unexpect;
+        char m_no_init;
+    };
+    bool m_has_val;
+};
+
+// E is trivial, T is not.
+template <class T, class E> struct expected_storage_base<T, E, false, true> {
+    constexpr expected_storage_base() : m_val(T{}), m_has_val(true) {}
+    constexpr expected_storage_base(no_init_t) : m_no_init(), m_has_val(false) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            nullptr>
+    constexpr expected_storage_base(in_place_t, Args &&...args)
+            : m_val(std::forward<Args>(args)...), m_has_val(true) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr expected_storage_base(in_place_t, std::initializer_list<U> il,
+                                    Args &&...args)
+            : m_val(il, std::forward<Args>(args)...), m_has_val(true) {}
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+            : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected_storage_base(unexpect_t,
+                                             std::initializer_list<U> il,
+                                             Args &&...args)
+            : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
+
+    ~expected_storage_base() {
+        if (m_has_val) {
+            m_val.~T();
+        }
+    }
+    union {
+        T m_val;
+        unexpected<E> m_unexpect;
+        char m_no_init;
+    };
+    bool m_has_val;
+};
+
+// `T` is `void`, `E` is trivially-destructible
+template <class E> struct expected_storage_base<void, E, false, true> {
+    #if __GNUC__ <= 5
+    //no constexpr for GCC 4/5 bug
+    #else
+    BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR
+    #endif
+    expected_storage_base() : m_has_val(true) {}
+
+    constexpr expected_storage_base(no_init_t) : m_val(), m_has_val(false) {}
+
+    constexpr expected_storage_base(in_place_t) : m_has_val(true) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+            : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected_storage_base(unexpect_t,
+                                             std::initializer_list<U> il,
+                                             Args &&...args)
+            : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
+
+    ~expected_storage_base() = default;
+    struct dummy {};
+    union {
+        unexpected<E> m_unexpect;
+        dummy m_val;
+    };
+    bool m_has_val;
+};
+
+// `T` is `void`, `E` is not trivially-destructible
+template <class E> struct expected_storage_base<void, E, false, false> {
+    constexpr expected_storage_base() : m_dummy(), m_has_val(true) {}
+    constexpr expected_storage_base(no_init_t) : m_dummy(), m_has_val(false) {}
+
+    constexpr expected_storage_base(in_place_t) : m_dummy(), m_has_val(true) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected_storage_base(unexpect_t, Args &&...args)
+            : m_unexpect(std::forward<Args>(args)...), m_has_val(false) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected_storage_base(unexpect_t,
+                                             std::initializer_list<U> il,
+                                             Args &&...args)
+            : m_unexpect(il, std::forward<Args>(args)...), m_has_val(false) {}
+
+    ~expected_storage_base() {
+        if (!m_has_val) {
+            m_unexpect.~unexpected<E>();
+        }
+    }
+
+    union {
+        unexpected<E> m_unexpect;
+        char m_dummy;
+    };
+    bool m_has_val;
+};
+
+// This base class provides some handy member functions which can be used in
+// further derived classes
+template <class T, class E>
+struct expected_operations_base : expected_storage_base<T, E> {
+    using expected_storage_base<T, E>::expected_storage_base;
+
+    template <class... Args> void construct(Args &&...args) noexcept {
+        new (std::addressof(this->m_val)) T(std::forward<Args>(args)...);
+        this->m_has_val = true;
+    }
+
+    template <class Rhs> void construct_with(Rhs &&rhs) noexcept {
+        new (std::addressof(this->m_val)) T(std::forward<Rhs>(rhs).get());
+        this->m_has_val = true;
+    }
+
+    template <class... Args> void construct_error(Args &&...args) noexcept {
+        new (std::addressof(this->m_unexpect))
+                unexpected<E>(std::forward<Args>(args)...);
+        this->m_has_val = false;
+    }
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+
+    // These assign overloads ensure that the most efficient assignment
+    // implementation is used while maintaining the strong exception guarantee.
+    // The problematic case is where rhs has a value, but *this does not.
+    //
+    // This overload handles the case where we can just copy-construct `T`
+    // directly into place without throwing.
+    template <class U = T,
+            detail::enable_if_t<std::is_nothrow_copy_constructible<U>::value>
+            * = nullptr>
+    void assign(const expected_operations_base &rhs) noexcept {
+        if (!this->m_has_val && rhs.m_has_val) {
+            geterr().~unexpected<E>();
+            construct(rhs.get());
+        } else {
+            assign_common(rhs);
+        }
+    }
+
+    // This overload handles the case where we can attempt to create a copy of
+    // `T`, then no-throw move it into place if the copy was successful.
+    template <class U = T,
+            detail::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
+                                std::is_nothrow_move_constructible<U>::value>
+            * = nullptr>
+    void assign(const expected_operations_base &rhs) noexcept {
+        if (!this->m_has_val && rhs.m_has_val) {
+            T tmp = rhs.get();
+            geterr().~unexpected<E>();
+            construct(std::move(tmp));
+        } else {
+            assign_common(rhs);
+        }
+    }
+
+    // This overload is the worst-case, where we have to move-construct the
+    // unexpected value into temporary storage, then try to copy the T into place.
+    // If the construction succeeds, then everything is fine, but if it throws,
+    // then we move the old unexpected value back into place before rethrowing the
+    // exception.
+    template <class U = T,
+            detail::enable_if_t<!std::is_nothrow_copy_constructible<U>::value &&
+                                !std::is_nothrow_move_constructible<U>::value>
+            * = nullptr>
+    void assign(const expected_operations_base &rhs) {
+        if (!this->m_has_val && rhs.m_has_val) {
+            auto tmp = std::move(geterr());
+            geterr().~unexpected<E>();
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+            try {
+                construct(rhs.get());
+            } catch (...) {
+                geterr() = std::move(tmp);
+                throw;
+            }
+#else
+            construct(rhs.get());
+#endif
+        } else {
+            assign_common(rhs);
+        }
+    }
+
+    // These overloads do the same as above, but for rvalues
+    template <class U = T,
+            detail::enable_if_t<std::is_nothrow_move_constructible<U>::value>
+            * = nullptr>
+    void assign(expected_operations_base &&rhs) noexcept {
+        if (!this->m_has_val && rhs.m_has_val) {
+            geterr().~unexpected<E>();
+            construct(std::move(rhs).get());
+        } else {
+            assign_common(std::move(rhs));
+        }
+    }
+
+    template <class U = T,
+            detail::enable_if_t<!std::is_nothrow_move_constructible<U>::value>
+            * = nullptr>
+    void assign(expected_operations_base &&rhs) {
+        if (!this->m_has_val && rhs.m_has_val) {
+            auto tmp = std::move(geterr());
+            geterr().~unexpected<E>();
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+            try {
+                construct(std::move(rhs).get());
+            } catch (...) {
+                geterr() = std::move(tmp);
+                throw;
+            }
+#else
+            construct(std::move(rhs).get());
+#endif
+        } else {
+            assign_common(std::move(rhs));
+        }
+    }
+
+#else
+
+    // If exceptions are disabled then we can just copy-construct
+  void assign(const expected_operations_base &rhs) noexcept {
+    if (!this->m_has_val && rhs.m_has_val) {
+      geterr().~unexpected<E>();
+      construct(rhs.get());
+    } else {
+      assign_common(rhs);
+    }
+  }
+
+  void assign(expected_operations_base &&rhs) noexcept {
+    if (!this->m_has_val && rhs.m_has_val) {
+      geterr().~unexpected<E>();
+      construct(std::move(rhs).get());
+    } else {
+      assign_common(std::move(rhs));
+    }
+  }
+
+#endif
+
+    // The common part of move/copy assigning
+    template <class Rhs> void assign_common(Rhs &&rhs) {
+        if (this->m_has_val) {
+            if (rhs.m_has_val) {
+                get() = std::forward<Rhs>(rhs).get();
+            } else {
+                destroy_val();
+                construct_error(std::forward<Rhs>(rhs).geterr());
+            }
+        } else {
+            if (!rhs.m_has_val) {
+                geterr() = std::forward<Rhs>(rhs).geterr();
+            }
+        }
+    }
+
+    bool has_value() const { return this->m_has_val; }
+
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR T &get() & { return this->m_val; }
+    constexpr const T &get() const & { return this->m_val; }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR T &&get() && { return std::move(this->m_val); }
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+    constexpr const T &&get() const && { return std::move(this->m_val); }
+#endif
+
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR unexpected<E> &geterr() & {
+        return this->m_unexpect;
+    }
+    constexpr const unexpected<E> &geterr() const & { return this->m_unexpect; }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR unexpected<E> &&geterr() && {
+        return std::move(this->m_unexpect);
+    }
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+    constexpr const unexpected<E> &&geterr() const && {
+        return std::move(this->m_unexpect);
+    }
+#endif
+
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR void destroy_val() { get().~T(); }
+};
+
+// This base class provides some handy member functions which can be used in
+// further derived classes
+template <class E>
+struct expected_operations_base<void, E> : expected_storage_base<void, E> {
+    using expected_storage_base<void, E>::expected_storage_base;
+
+    template <class... Args> void construct() noexcept { this->m_has_val = true; }
+
+    // This function doesn't use its argument, but needs it so that code in
+    // levels above this can work independently of whether T is void
+    template <class Rhs> void construct_with(Rhs &&) noexcept {
+        this->m_has_val = true;
+    }
+
+    template <class... Args> void construct_error(Args &&...args) noexcept {
+        new (std::addressof(this->m_unexpect))
+                unexpected<E>(std::forward<Args>(args)...);
+        this->m_has_val = false;
+    }
+
+    template <class Rhs> void assign(Rhs &&rhs) noexcept {
+        if (!this->m_has_val) {
+            if (rhs.m_has_val) {
+                geterr().~unexpected<E>();
+                construct();
+            } else {
+                geterr() = std::forward<Rhs>(rhs).geterr();
+            }
+        } else {
+            if (!rhs.m_has_val) {
+                construct_error(std::forward<Rhs>(rhs).geterr());
+            }
+        }
+    }
+
+    bool has_value() const { return this->m_has_val; }
+
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR unexpected<E> &geterr() & {
+        return this->m_unexpect;
+    }
+    constexpr const unexpected<E> &geterr() const & { return this->m_unexpect; }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR unexpected<E> &&geterr() && {
+        return std::move(this->m_unexpect);
+    }
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+    constexpr const unexpected<E> &&geterr() const && {
+        return std::move(this->m_unexpect);
+    }
+#endif
+
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR void destroy_val() {
+        // no-op
+    }
+};
+
+// This class manages conditionally having a trivial copy constructor
+// This specialization is for when T and E are trivially copy constructible
+template <class T, class E,
+        bool = is_void_or<T, BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)>::
+               value &&BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(E)::value>
+struct expected_copy_base : expected_operations_base<T, E> {
+    using expected_operations_base<T, E>::expected_operations_base;
+};
+
+// This specialization is for when T or E are not trivially copy constructible
+template <class T, class E>
+struct expected_copy_base<T, E, false> : expected_operations_base<T, E> {
+    using expected_operations_base<T, E>::expected_operations_base;
+
+    expected_copy_base() = default;
+    expected_copy_base(const expected_copy_base &rhs)
+            : expected_operations_base<T, E>(no_init) {
+        if (rhs.has_value()) {
+            this->construct_with(rhs);
+        } else {
+            this->construct_error(rhs.geterr());
+        }
+    }
+
+    expected_copy_base(expected_copy_base &&rhs) = default;
+    expected_copy_base &operator=(const expected_copy_base &rhs) = default;
+    expected_copy_base &operator=(expected_copy_base &&rhs) = default;
+};
+
+// This class manages conditionally having a trivial move constructor
+// Unfortunately there's no way to achieve this in GCC < 5 AFAIK, since it
+// doesn't implement an analogue to std::is_trivially_move_constructible. We
+// have to make do with a non-trivial move constructor even if T is trivially
+// move constructible
+#ifndef BOOST_CRYPT_TL_EXPECTED_GCC49
+template <class T, class E,
+        bool = is_void_or<T, std::is_trivially_move_constructible<T>>::value
+               &&std::is_trivially_move_constructible<E>::value>
+struct expected_move_base : expected_copy_base<T, E> {
+    using expected_copy_base<T, E>::expected_copy_base;
+};
+#else
+template <class T, class E, bool = false> struct expected_move_base;
+#endif
+template <class T, class E>
+struct expected_move_base<T, E, false> : expected_copy_base<T, E> {
+    using expected_copy_base<T, E>::expected_copy_base;
+
+    expected_move_base() = default;
+    expected_move_base(const expected_move_base &rhs) = default;
+
+    expected_move_base(expected_move_base &&rhs) noexcept(
+    std::is_nothrow_move_constructible<T>::value)
+            : expected_copy_base<T, E>(no_init) {
+        if (rhs.has_value()) {
+            this->construct_with(std::move(rhs));
+        } else {
+            this->construct_error(std::move(rhs.geterr()));
+        }
+    }
+    expected_move_base &operator=(const expected_move_base &rhs) = default;
+    expected_move_base &operator=(expected_move_base &&rhs) = default;
+};
+
+// This class manages conditionally having a trivial copy assignment operator
+template <class T, class E,
+        bool = is_void_or<
+                T, conjunction<BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(T),
+                        BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T),
+                        BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(T)>>::value
+               &&BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_ASSIGNABLE(E)::value
+               &&BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(E)::value
+               &&BOOST_CRYPT_TL_EXPECTED_IS_TRIVIALLY_DESTRUCTIBLE(E)::value>
+struct expected_copy_assign_base : expected_move_base<T, E> {
+    using expected_move_base<T, E>::expected_move_base;
+};
+
+template <class T, class E>
+struct expected_copy_assign_base<T, E, false> : expected_move_base<T, E> {
+    using expected_move_base<T, E>::expected_move_base;
+
+    expected_copy_assign_base() = default;
+    expected_copy_assign_base(const expected_copy_assign_base &rhs) = default;
+
+    expected_copy_assign_base(expected_copy_assign_base &&rhs) = default;
+    expected_copy_assign_base &operator=(const expected_copy_assign_base &rhs) {
+        this->assign(rhs);
+        return *this;
+    }
+    expected_copy_assign_base &
+    operator=(expected_copy_assign_base &&rhs) = default;
+};
+
+// This class manages conditionally having a trivial move assignment operator
+// Unfortunately there's no way to achieve this in GCC < 5 AFAIK, since it
+// doesn't implement an analogue to std::is_trivially_move_assignable. We have
+// to make do with a non-trivial move assignment operator even if T is trivially
+// move assignable
+#ifndef BOOST_CRYPT_TL_EXPECTED_GCC49
+template <class T, class E,
+        bool =
+        is_void_or<T, conjunction<std::is_trivially_destructible<T>,
+                std::is_trivially_move_constructible<T>,
+                std::is_trivially_move_assignable<T>>>::
+        value &&std::is_trivially_destructible<E>::value
+        &&std::is_trivially_move_constructible<E>::value
+        &&std::is_trivially_move_assignable<E>::value>
+struct expected_move_assign_base : expected_copy_assign_base<T, E> {
+    using expected_copy_assign_base<T, E>::expected_copy_assign_base;
+};
+#else
+template <class T, class E, bool = false> struct expected_move_assign_base;
+#endif
+
+template <class T, class E>
+struct expected_move_assign_base<T, E, false>
+        : expected_copy_assign_base<T, E> {
+    using expected_copy_assign_base<T, E>::expected_copy_assign_base;
+
+    expected_move_assign_base() = default;
+    expected_move_assign_base(const expected_move_assign_base &rhs) = default;
+
+    expected_move_assign_base(expected_move_assign_base &&rhs) = default;
+
+    expected_move_assign_base &
+    operator=(const expected_move_assign_base &rhs) = default;
+
+    expected_move_assign_base &
+    operator=(expected_move_assign_base &&rhs) noexcept(
+    std::is_nothrow_move_constructible<T>::value
+    &&std::is_nothrow_move_assignable<T>::value) {
+        this->assign(std::move(rhs));
+        return *this;
+    }
+};
+
+// expected_delete_ctor_base will conditionally delete copy and move
+// constructors depending on whether T is copy/move constructible
+template <class T, class E,
+        bool EnableCopy = (is_copy_constructible_or_void<T>::value &&
+                           std::is_copy_constructible<E>::value),
+        bool EnableMove = (is_move_constructible_or_void<T>::value &&
+                           std::is_move_constructible<E>::value)>
+struct expected_delete_ctor_base {
+    expected_delete_ctor_base() = default;
+    expected_delete_ctor_base(const expected_delete_ctor_base &) = default;
+    expected_delete_ctor_base(expected_delete_ctor_base &&) noexcept = default;
+    expected_delete_ctor_base &
+    operator=(const expected_delete_ctor_base &) = default;
+    expected_delete_ctor_base &
+    operator=(expected_delete_ctor_base &&) noexcept = default;
+};
+
+template <class T, class E>
+struct expected_delete_ctor_base<T, E, true, false> {
+    expected_delete_ctor_base() = default;
+    expected_delete_ctor_base(const expected_delete_ctor_base &) = default;
+    expected_delete_ctor_base(expected_delete_ctor_base &&) noexcept = delete;
+    expected_delete_ctor_base &
+    operator=(const expected_delete_ctor_base &) = default;
+    expected_delete_ctor_base &
+    operator=(expected_delete_ctor_base &&) noexcept = default;
+};
+
+template <class T, class E>
+struct expected_delete_ctor_base<T, E, false, true> {
+    expected_delete_ctor_base() = default;
+    expected_delete_ctor_base(const expected_delete_ctor_base &) = delete;
+    expected_delete_ctor_base(expected_delete_ctor_base &&) noexcept = default;
+    expected_delete_ctor_base &
+    operator=(const expected_delete_ctor_base &) = default;
+    expected_delete_ctor_base &
+    operator=(expected_delete_ctor_base &&) noexcept = default;
+};
+
+template <class T, class E>
+struct expected_delete_ctor_base<T, E, false, false> {
+    expected_delete_ctor_base() = default;
+    expected_delete_ctor_base(const expected_delete_ctor_base &) = delete;
+    expected_delete_ctor_base(expected_delete_ctor_base &&) noexcept = delete;
+    expected_delete_ctor_base &
+    operator=(const expected_delete_ctor_base &) = default;
+    expected_delete_ctor_base &
+    operator=(expected_delete_ctor_base &&) noexcept = default;
+};
+
+// expected_delete_assign_base will conditionally delete copy and move
+// constructors depending on whether T and E are copy/move constructible +
+// assignable
+template <class T, class E,
+        bool EnableCopy = (is_copy_constructible_or_void<T>::value &&
+                           std::is_copy_constructible<E>::value &&
+                           is_copy_assignable_or_void<T>::value &&
+                           std::is_copy_assignable<E>::value),
+        bool EnableMove = (is_move_constructible_or_void<T>::value &&
+                           std::is_move_constructible<E>::value &&
+                           is_move_assignable_or_void<T>::value &&
+                           std::is_move_assignable<E>::value)>
+struct expected_delete_assign_base {
+    expected_delete_assign_base() = default;
+    expected_delete_assign_base(const expected_delete_assign_base &) = default;
+    expected_delete_assign_base(expected_delete_assign_base &&) noexcept =
+    default;
+    expected_delete_assign_base &
+    operator=(const expected_delete_assign_base &) = default;
+    expected_delete_assign_base &
+    operator=(expected_delete_assign_base &&) noexcept = default;
+};
+
+template <class T, class E>
+struct expected_delete_assign_base<T, E, true, false> {
+    expected_delete_assign_base() = default;
+    expected_delete_assign_base(const expected_delete_assign_base &) = default;
+    expected_delete_assign_base(expected_delete_assign_base &&) noexcept =
+    default;
+    expected_delete_assign_base &
+    operator=(const expected_delete_assign_base &) = default;
+    expected_delete_assign_base &
+    operator=(expected_delete_assign_base &&) noexcept = delete;
+};
+
+template <class T, class E>
+struct expected_delete_assign_base<T, E, false, true> {
+    expected_delete_assign_base() = default;
+    expected_delete_assign_base(const expected_delete_assign_base &) = default;
+    expected_delete_assign_base(expected_delete_assign_base &&) noexcept =
+    default;
+    expected_delete_assign_base &
+    operator=(const expected_delete_assign_base &) = delete;
+    expected_delete_assign_base &
+    operator=(expected_delete_assign_base &&) noexcept = default;
+};
+
+template <class T, class E>
+struct expected_delete_assign_base<T, E, false, false> {
+    expected_delete_assign_base() = default;
+    expected_delete_assign_base(const expected_delete_assign_base &) = default;
+    expected_delete_assign_base(expected_delete_assign_base &&) noexcept =
+    default;
+    expected_delete_assign_base &
+    operator=(const expected_delete_assign_base &) = delete;
+    expected_delete_assign_base &
+    operator=(expected_delete_assign_base &&) noexcept = delete;
+};
+
+// This is needed to be able to construct the expected_default_ctor_base which
+// follows, while still conditionally deleting the default constructor.
+struct default_constructor_tag {
+    explicit constexpr default_constructor_tag() = default;
+};
+
+// expected_default_ctor_base will ensure that expected has a deleted default
+// consturctor if T is not default constructible.
+// This specialization is for when T is default constructible
+template <class T, class E,
+        bool Enable =
+        std::is_default_constructible<T>::value || std::is_void<T>::value>
+struct expected_default_ctor_base {
+    constexpr expected_default_ctor_base() noexcept = default;
+    constexpr expected_default_ctor_base(
+            expected_default_ctor_base const &) noexcept = default;
+    constexpr expected_default_ctor_base(expected_default_ctor_base &&) noexcept =
+    default;
+    expected_default_ctor_base &
+    operator=(expected_default_ctor_base const &) noexcept = default;
+    expected_default_ctor_base &
+    operator=(expected_default_ctor_base &&) noexcept = default;
+
+    constexpr explicit expected_default_ctor_base(default_constructor_tag) {}
+};
+
+// This specialization is for when T is not default constructible
+template <class T, class E> struct expected_default_ctor_base<T, E, false> {
+    constexpr expected_default_ctor_base() noexcept = delete;
+    constexpr expected_default_ctor_base(
+            expected_default_ctor_base const &) noexcept = default;
+    constexpr expected_default_ctor_base(expected_default_ctor_base &&) noexcept =
+    default;
+    expected_default_ctor_base &
+    operator=(expected_default_ctor_base const &) noexcept = default;
+    expected_default_ctor_base &
+    operator=(expected_default_ctor_base &&) noexcept = default;
+
+    constexpr explicit expected_default_ctor_base(default_constructor_tag) {}
+};
+} // namespace detail
+
+template <class E> class bad_expected_access : public std::exception {
+public:
+    explicit bad_expected_access(E e) : m_val(std::move(e)) {}
+
+    virtual const char *what() const noexcept override {
+        return "Bad expected access";
+    }
+
+    const E &error() const & { return m_val; }
+    E &error() & { return m_val; }
+    const E &&error() const && { return std::move(m_val); }
+    E &&error() && { return std::move(m_val); }
+
+private:
+    E m_val;
+};
+
+/// An `expected<T, E>` object is an object that contains the storage for
+/// another object and manages the lifetime of this contained object `T`.
+/// Alternatively it could contain the storage for another unexpected object
+/// `E`. The contained object may not be initialized after the expected object
+/// has been initialized, and may not be destroyed before the expected object
+/// has been destroyed. The initialization state of the contained object is
+/// tracked by the expected object.
+template <class T, class E>
+class expected : private detail::expected_move_assign_base<T, E>,
+                 private detail::expected_delete_ctor_base<T, E>,
+                 private detail::expected_delete_assign_base<T, E>,
+                 private detail::expected_default_ctor_base<T, E> {
+    static_assert(!std::is_reference<T>::value, "T must not be a reference");
+    static_assert(!std::is_same<T, std::remove_cv<in_place_t>::type>::value,
+                  "T must not be in_place_t");
+    static_assert(!std::is_same<T, std::remove_cv<unexpect_t>::type>::value,
+                  "T must not be unexpect_t");
+    static_assert(
+            !std::is_same<T, typename std::remove_cv<unexpected<E>>::type>::value,
+            "T must not be unexpected<E>");
+    static_assert(!std::is_reference<E>::value, "E must not be a reference");
+
+    T *valptr() { return std::addressof(this->m_val); }
+    const T *valptr() const { return std::addressof(this->m_val); }
+    unexpected<E> *errptr() { return std::addressof(this->m_unexpect); }
+    const unexpected<E> *errptr() const {
+        return std::addressof(this->m_unexpect);
+    }
+
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR U &val() {
+        return this->m_val;
+    }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR unexpected<E> &err() { return this->m_unexpect; }
+
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    constexpr const U &val() const {
+        return this->m_val;
+    }
+    constexpr const unexpected<E> &err() const { return this->m_unexpect; }
+
+    using impl_base = detail::expected_move_assign_base<T, E>;
+    using ctor_base = detail::expected_default_ctor_base<T, E>;
+
+public:
+    typedef T value_type;
+    typedef E error_type;
+    typedef unexpected<E> unexpected_type;
+
+#if defined(BOOST_CRYPT_TL_EXPECTED_CXX14) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC49) &&               \
+    !defined(BOOST_CRYPT_TL_EXPECTED_GCC54) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC55)
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto and_then(F &&f) & {
+        return and_then_impl(*this, std::forward<F>(f));
+    }
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto and_then(F &&f) && {
+        return and_then_impl(std::move(*this), std::forward<F>(f));
+    }
+    template <class F> constexpr auto and_then(F &&f) const & {
+        return and_then_impl(*this, std::forward<F>(f));
+    }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+    template <class F> constexpr auto and_then(F &&f) const && {
+        return and_then_impl(std::move(*this), std::forward<F>(f));
+    }
+#endif
+
+#else
+    template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto
+  and_then(F &&f) & -> decltype(and_then_impl(std::declval<expected &>(),
+                                              std::forward<F>(f))) {
+    return and_then_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto
+  and_then(F &&f) && -> decltype(and_then_impl(std::declval<expected &&>(),
+                                               std::forward<F>(f))) {
+    return and_then_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr auto and_then(F &&f) const & -> decltype(and_then_impl(
+      std::declval<expected const &>(), std::forward<F>(f))) {
+    return and_then_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+  template <class F>
+  constexpr auto and_then(F &&f) const && -> decltype(and_then_impl(
+      std::declval<expected const &&>(), std::forward<F>(f))) {
+    return and_then_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+#if defined(BOOST_CRYPT_TL_EXPECTED_CXX14) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC49) &&               \
+    !defined(BOOST_CRYPT_TL_EXPECTED_GCC54) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC55)
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto map(F &&f) & {
+        return expected_map_impl(*this, std::forward<F>(f));
+    }
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto map(F &&f) && {
+        return expected_map_impl(std::move(*this), std::forward<F>(f));
+    }
+    template <class F> constexpr auto map(F &&f) const & {
+        return expected_map_impl(*this, std::forward<F>(f));
+    }
+    template <class F> constexpr auto map(F &&f) const && {
+        return expected_map_impl(std::move(*this), std::forward<F>(f));
+    }
+#else
+    template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(expected_map_impl(
+      std::declval<expected &>(), std::declval<F &&>()))
+  map(F &&f) & {
+    return expected_map_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(expected_map_impl(std::declval<expected>(),
+                                                      std::declval<F &&>()))
+  map(F &&f) && {
+    return expected_map_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr decltype(expected_map_impl(std::declval<const expected &>(),
+                                       std::declval<F &&>()))
+  map(F &&f) const & {
+    return expected_map_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+  template <class F>
+  constexpr decltype(expected_map_impl(std::declval<const expected &&>(),
+                                       std::declval<F &&>()))
+  map(F &&f) const && {
+    return expected_map_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+#if defined(BOOST_CRYPT_TL_EXPECTED_CXX14) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC49) &&               \
+    !defined(BOOST_CRYPT_TL_EXPECTED_GCC54) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC55)
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto transform(F &&f) & {
+        return expected_map_impl(*this, std::forward<F>(f));
+    }
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto transform(F &&f) && {
+        return expected_map_impl(std::move(*this), std::forward<F>(f));
+    }
+    template <class F> constexpr auto transform(F &&f) const & {
+        return expected_map_impl(*this, std::forward<F>(f));
+    }
+    template <class F> constexpr auto transform(F &&f) const && {
+        return expected_map_impl(std::move(*this), std::forward<F>(f));
+    }
+#else
+    template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(expected_map_impl(
+      std::declval<expected &>(), std::declval<F &&>()))
+  transform(F &&f) & {
+    return expected_map_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(expected_map_impl(std::declval<expected>(),
+                                                      std::declval<F &&>()))
+  transform(F &&f) && {
+    return expected_map_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr decltype(expected_map_impl(std::declval<const expected &>(),
+                                       std::declval<F &&>()))
+  transform(F &&f) const & {
+    return expected_map_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+  template <class F>
+  constexpr decltype(expected_map_impl(std::declval<const expected &&>(),
+                                       std::declval<F &&>()))
+  transform(F &&f) const && {
+    return expected_map_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+#if defined(BOOST_CRYPT_TL_EXPECTED_CXX14) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC49) &&               \
+    !defined(BOOST_CRYPT_TL_EXPECTED_GCC54) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC55)
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto map_error(F &&f) & {
+        return map_error_impl(*this, std::forward<F>(f));
+    }
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto map_error(F &&f) && {
+        return map_error_impl(std::move(*this), std::forward<F>(f));
+    }
+    template <class F> constexpr auto map_error(F &&f) const & {
+        return map_error_impl(*this, std::forward<F>(f));
+    }
+    template <class F> constexpr auto map_error(F &&f) const && {
+        return map_error_impl(std::move(*this), std::forward<F>(f));
+    }
+#else
+    template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(map_error_impl(std::declval<expected &>(),
+                                                   std::declval<F &&>()))
+  map_error(F &&f) & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(map_error_impl(std::declval<expected &&>(),
+                                                   std::declval<F &&>()))
+  map_error(F &&f) && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr decltype(map_error_impl(std::declval<const expected &>(),
+                                    std::declval<F &&>()))
+  map_error(F &&f) const & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+  template <class F>
+  constexpr decltype(map_error_impl(std::declval<const expected &&>(),
+                                    std::declval<F &&>()))
+  map_error(F &&f) const && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+#if defined(BOOST_CRYPT_TL_EXPECTED_CXX14) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC49) &&               \
+    !defined(BOOST_CRYPT_TL_EXPECTED_GCC54) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC55)
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto transform_error(F &&f) & {
+        return map_error_impl(*this, std::forward<F>(f));
+    }
+    template <class F> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR auto transform_error(F &&f) && {
+        return map_error_impl(std::move(*this), std::forward<F>(f));
+    }
+    template <class F> constexpr auto transform_error(F &&f) const & {
+        return map_error_impl(*this, std::forward<F>(f));
+    }
+    template <class F> constexpr auto transform_error(F &&f) const && {
+        return map_error_impl(std::move(*this), std::forward<F>(f));
+    }
+#else
+    template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(map_error_impl(std::declval<expected &>(),
+                                                   std::declval<F &&>()))
+  transform_error(F &&f) & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+  template <class F>
+  BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR decltype(map_error_impl(std::declval<expected &&>(),
+                                                   std::declval<F &&>()))
+  transform_error(F &&f) && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+  template <class F>
+  constexpr decltype(map_error_impl(std::declval<const expected &>(),
+                                    std::declval<F &&>()))
+  transform_error(F &&f) const & {
+    return map_error_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+  template <class F>
+  constexpr decltype(map_error_impl(std::declval<const expected &&>(),
+                                    std::declval<F &&>()))
+  transform_error(F &&f) const && {
+    return map_error_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+    template <class F> expected BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR or_else(F &&f) & {
+        return or_else_impl(*this, std::forward<F>(f));
+    }
+
+    template <class F> expected BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR or_else(F &&f) && {
+        return or_else_impl(std::move(*this), std::forward<F>(f));
+    }
+
+    template <class F> expected constexpr or_else(F &&f) const & {
+        return or_else_impl(*this, std::forward<F>(f));
+    }
+
+#ifndef BOOST_CRYPT_TL_EXPECTED_NO_CONSTRR
+    template <class F> expected constexpr or_else(F &&f) const && {
+        return or_else_impl(std::move(*this), std::forward<F>(f));
+    }
+#endif
+    constexpr expected() = default;
+    constexpr expected(const expected &rhs) = default;
+    constexpr expected(expected &&rhs) = default;
+    expected &operator=(const expected &rhs) = default;
+    expected &operator=(expected &&rhs) = default;
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<T, Args &&...>::value> * =
+            nullptr>
+    constexpr expected(in_place_t, Args &&...args)
+            : impl_base(in_place, std::forward<Args>(args)...),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr expected(in_place_t, std::initializer_list<U> il, Args &&...args)
+            : impl_base(in_place, il, std::forward<Args>(args)...),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <class G = E,
+            detail::enable_if_t<std::is_constructible<E, const G &>::value> * =
+            nullptr,
+            detail::enable_if_t<!std::is_convertible<const G &, E>::value> * =
+            nullptr>
+    explicit constexpr expected(const unexpected<G> &e)
+            : impl_base(unexpect, e.value()),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <
+            class G = E,
+            detail::enable_if_t<std::is_constructible<E, const G &>::value> * =
+            nullptr,
+            detail::enable_if_t<std::is_convertible<const G &, E>::value> * = nullptr>
+    constexpr expected(unexpected<G> const &e)
+            : impl_base(unexpect, e.value()),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <
+            class G = E,
+            detail::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
+            detail::enable_if_t<!std::is_convertible<G &&, E>::value> * = nullptr>
+    explicit constexpr expected(unexpected<G> &&e) noexcept(
+    std::is_nothrow_constructible<E, G &&>::value)
+            : impl_base(unexpect, std::move(e.value())),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <
+            class G = E,
+            detail::enable_if_t<std::is_constructible<E, G &&>::value> * = nullptr,
+            detail::enable_if_t<std::is_convertible<G &&, E>::value> * = nullptr>
+    constexpr expected(unexpected<G> &&e) noexcept(
+    std::is_nothrow_constructible<E, G &&>::value)
+            : impl_base(unexpect, std::move(e.value())),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <class... Args,
+            detail::enable_if_t<std::is_constructible<E, Args &&...>::value> * =
+            nullptr>
+    constexpr explicit expected(unexpect_t, Args &&...args)
+            : impl_base(unexpect, std::forward<Args>(args)...),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_constructible<
+                    E, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    constexpr explicit expected(unexpect_t, std::initializer_list<U> il,
+                                Args &&...args)
+            : impl_base(unexpect, il, std::forward<Args>(args)...),
+              ctor_base(detail::default_constructor_tag{}) {}
+
+    template <class U, class G,
+            detail::enable_if_t<!(std::is_convertible<U const &, T>::value &&
+                                  std::is_convertible<G const &, E>::value)> * =
+            nullptr,
+            detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
+            * = nullptr>
+    explicit BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR expected(const expected<U, G> &rhs)
+            : ctor_base(detail::default_constructor_tag{}) {
+        if (rhs.has_value()) {
+            this->construct(*rhs);
+        } else {
+            this->construct_error(rhs.error());
+        }
+    }
+
+    template <class U, class G,
+            detail::enable_if_t<(std::is_convertible<U const &, T>::value &&
+                                 std::is_convertible<G const &, E>::value)> * =
+            nullptr,
+            detail::expected_enable_from_other<T, E, U, G, const U &, const G &>
+            * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR expected(const expected<U, G> &rhs)
+            : ctor_base(detail::default_constructor_tag{}) {
+        if (rhs.has_value()) {
+            this->construct(*rhs);
+        } else {
+            this->construct_error(rhs.error());
+        }
+    }
+
+    template <
+            class U, class G,
+            detail::enable_if_t<!(std::is_convertible<U &&, T>::value &&
+                                  std::is_convertible<G &&, E>::value)> * = nullptr,
+            detail::expected_enable_from_other<T, E, U, G, U &&, G &&> * = nullptr>
+    explicit BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR expected(expected<U, G> &&rhs)
+            : ctor_base(detail::default_constructor_tag{}) {
+        if (rhs.has_value()) {
+            this->construct(std::move(*rhs));
+        } else {
+            this->construct_error(std::move(rhs.error()));
+        }
+    }
+
+    template <
+            class U, class G,
+            detail::enable_if_t<(std::is_convertible<U &&, T>::value &&
+                                 std::is_convertible<G &&, E>::value)> * = nullptr,
+            detail::expected_enable_from_other<T, E, U, G, U &&, G &&> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR expected(expected<U, G> &&rhs)
+            : ctor_base(detail::default_constructor_tag{}) {
+        if (rhs.has_value()) {
+            this->construct(std::move(*rhs));
+        } else {
+            this->construct_error(std::move(rhs.error()));
+        }
+    }
+
+    template <
+            class U = T,
+            detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
+            detail::expected_enable_forward_value<T, E, U> * = nullptr>
+    explicit BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v)
+            : expected(in_place, std::forward<U>(v)) {}
+
+    template <
+            class U = T,
+            detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
+            detail::expected_enable_forward_value<T, E, U> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR expected(U &&v)
+            : expected(in_place, std::forward<U>(v)) {}
+
+    template <
+            class U = T, class G = T,
+            detail::enable_if_t<std::is_nothrow_constructible<T, U &&>::value> * =
+            nullptr,
+            detail::enable_if_t<!std::is_void<G>::value> * = nullptr,
+            detail::enable_if_t<
+                    (!std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
+                     !detail::conjunction<std::is_scalar<T>,
+                             std::is_same<T, detail::decay_t<U>>>::value &&
+                     std::is_constructible<T, U>::value &&
+                     std::is_assignable<G &, U>::value &&
+                     std::is_nothrow_move_constructible<E>::value)> * = nullptr>
+    expected &operator=(U &&v) {
+        if (has_value()) {
+            val() = std::forward<U>(v);
+        } else {
+            err().~unexpected<E>();
+            ::new (valptr()) T(std::forward<U>(v));
+            this->m_has_val = true;
+        }
+
+        return *this;
+    }
+
+    template <
+            class U = T, class G = T,
+            detail::enable_if_t<!std::is_nothrow_constructible<T, U &&>::value> * =
+            nullptr,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr,
+            detail::enable_if_t<
+                    (!std::is_same<expected<T, E>, detail::decay_t<U>>::value &&
+                     !detail::conjunction<std::is_scalar<T>,
+                             std::is_same<T, detail::decay_t<U>>>::value &&
+                     std::is_constructible<T, U>::value &&
+                     std::is_assignable<G &, U>::value &&
+                     std::is_nothrow_move_constructible<E>::value)> * = nullptr>
+    expected &operator=(U &&v) {
+        if (has_value()) {
+            val() = std::forward<U>(v);
+        } else {
+            auto tmp = std::move(err());
+            err().~unexpected<E>();
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+            try {
+                ::new (valptr()) T(std::forward<U>(v));
+                this->m_has_val = true;
+            } catch (...) {
+                err() = std::move(tmp);
+                throw;
+            }
+#else
+            ::new (valptr()) T(std::forward<U>(v));
+      this->m_has_val = true;
+#endif
+        }
+
+        return *this;
+    }
+
+    template <class G = E,
+            detail::enable_if_t<std::is_nothrow_copy_constructible<G>::value &&
+                                std::is_assignable<G &, G>::value> * = nullptr>
+    expected &operator=(const unexpected<G> &rhs) {
+        if (!has_value()) {
+            err() = rhs;
+        } else {
+            this->destroy_val();
+            ::new (errptr()) unexpected<E>(rhs);
+            this->m_has_val = false;
+        }
+
+        return *this;
+    }
+
+    template <class G = E,
+            detail::enable_if_t<std::is_nothrow_move_constructible<G>::value &&
+                                std::is_move_assignable<G>::value> * = nullptr>
+    expected &operator=(unexpected<G> &&rhs) noexcept {
+        if (!has_value()) {
+            err() = std::move(rhs);
+        } else {
+            this->destroy_val();
+            ::new (errptr()) unexpected<E>(std::move(rhs));
+            this->m_has_val = false;
+        }
+
+        return *this;
+    }
+
+    template <class... Args, detail::enable_if_t<std::is_nothrow_constructible<
+            T, Args &&...>::value> * = nullptr>
+    void emplace(Args &&...args) {
+        if (has_value()) {
+            val().~T();
+        } else {
+            err().~unexpected<E>();
+            this->m_has_val = true;
+        }
+        ::new (valptr()) T(std::forward<Args>(args)...);
+    }
+
+    template <class... Args, detail::enable_if_t<!std::is_nothrow_constructible<
+            T, Args &&...>::value> * = nullptr>
+    void emplace(Args &&...args) {
+        if (has_value()) {
+            val().~T();
+            ::new (valptr()) T(std::forward<Args>(args)...);
+        } else {
+            auto tmp = std::move(err());
+            err().~unexpected<E>();
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+            try {
+                ::new (valptr()) T(std::forward<Args>(args)...);
+                this->m_has_val = true;
+            } catch (...) {
+                err() = std::move(tmp);
+                throw;
+            }
+#else
+            ::new (valptr()) T(std::forward<Args>(args)...);
+      this->m_has_val = true;
+#endif
+        }
+    }
+
+    template <class U, class... Args,
+            detail::enable_if_t<std::is_nothrow_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    void emplace(std::initializer_list<U> il, Args &&...args) {
+        if (has_value()) {
+            T t(il, std::forward<Args>(args)...);
+            val() = std::move(t);
+        } else {
+            err().~unexpected<E>();
+            ::new (valptr()) T(il, std::forward<Args>(args)...);
+            this->m_has_val = true;
+        }
+    }
+
+    template <class U, class... Args,
+            detail::enable_if_t<!std::is_nothrow_constructible<
+                    T, std::initializer_list<U> &, Args &&...>::value> * = nullptr>
+    void emplace(std::initializer_list<U> il, Args &&...args) {
+        if (has_value()) {
+            T t(il, std::forward<Args>(args)...);
+            val() = std::move(t);
+        } else {
+            auto tmp = std::move(err());
+            err().~unexpected<E>();
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+            try {
+                ::new (valptr()) T(il, std::forward<Args>(args)...);
+                this->m_has_val = true;
+            } catch (...) {
+                err() = std::move(tmp);
+                throw;
+            }
+#else
+            ::new (valptr()) T(il, std::forward<Args>(args)...);
+      this->m_has_val = true;
+#endif
+        }
+    }
+
+private:
+    using t_is_void = std::true_type;
+    using t_is_not_void = std::false_type;
+    using t_is_nothrow_move_constructible = std::true_type;
+    using move_constructing_t_can_throw = std::false_type;
+    using e_is_nothrow_move_constructible = std::true_type;
+    using move_constructing_e_can_throw = std::false_type;
+
+    void swap_where_both_have_value(expected & /*rhs*/, t_is_void) noexcept {
+        // swapping void is a no-op
+    }
+
+    void swap_where_both_have_value(expected &rhs, t_is_not_void) {
+        using std::swap;
+        swap(val(), rhs.val());
+    }
+
+    void swap_where_only_one_has_value(expected &rhs, t_is_void) noexcept(
+    std::is_nothrow_move_constructible<E>::value) {
+        ::new (errptr()) unexpected_type(std::move(rhs.err()));
+        rhs.err().~unexpected_type();
+        std::swap(this->m_has_val, rhs.m_has_val);
+    }
+
+    void swap_where_only_one_has_value(expected &rhs, t_is_not_void) {
+        swap_where_only_one_has_value_and_t_is_not_void(
+                rhs, typename std::is_nothrow_move_constructible<T>::type{},
+                typename std::is_nothrow_move_constructible<E>::type{});
+    }
+
+    void swap_where_only_one_has_value_and_t_is_not_void(
+            expected &rhs, t_is_nothrow_move_constructible,
+            e_is_nothrow_move_constructible) noexcept {
+        auto temp = std::move(val());
+        val().~T();
+        ::new (errptr()) unexpected_type(std::move(rhs.err()));
+        rhs.err().~unexpected_type();
+        ::new (rhs.valptr()) T(std::move(temp));
+        std::swap(this->m_has_val, rhs.m_has_val);
+    }
+
+    void swap_where_only_one_has_value_and_t_is_not_void(
+            expected &rhs, t_is_nothrow_move_constructible,
+            move_constructing_e_can_throw) {
+        auto temp = std::move(val());
+        val().~T();
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+        try {
+            ::new (errptr()) unexpected_type(std::move(rhs.err()));
+            rhs.err().~unexpected_type();
+            ::new (rhs.valptr()) T(std::move(temp));
+            std::swap(this->m_has_val, rhs.m_has_val);
+        } catch (...) {
+            val() = std::move(temp);
+            throw;
+        }
+#else
+        ::new (errptr()) unexpected_type(std::move(rhs.err()));
+    rhs.err().~unexpected_type();
+    ::new (rhs.valptr()) T(std::move(temp));
+    std::swap(this->m_has_val, rhs.m_has_val);
+#endif
+    }
+
+    void swap_where_only_one_has_value_and_t_is_not_void(
+            expected &rhs, move_constructing_t_can_throw,
+            e_is_nothrow_move_constructible) {
+        auto temp = std::move(rhs.err());
+        rhs.err().~unexpected_type();
+#ifdef BOOST_CRYPT_TL_EXPECTED_EXCEPTIONS_ENABLED
+        try {
+            ::new (rhs.valptr()) T(std::move(val()));
+            val().~T();
+            ::new (errptr()) unexpected_type(std::move(temp));
+            std::swap(this->m_has_val, rhs.m_has_val);
+        } catch (...) {
+            rhs.err() = std::move(temp);
+            throw;
+        }
+#else
+        ::new (rhs.valptr()) T(std::move(val()));
+    val().~T();
+    ::new (errptr()) unexpected_type(std::move(temp));
+    std::swap(this->m_has_val, rhs.m_has_val);
+#endif
+    }
+
+public:
+    template <class OT = T, class OE = E>
+    detail::enable_if_t<detail::is_swappable<OT>::value &&
+                        detail::is_swappable<OE>::value &&
+                        (std::is_nothrow_move_constructible<OT>::value ||
+                         std::is_nothrow_move_constructible<OE>::value)>
+    swap(expected &rhs) noexcept(
+    std::is_nothrow_move_constructible<T>::value
+    &&detail::is_nothrow_swappable<T>::value
+    &&std::is_nothrow_move_constructible<E>::value
+    &&detail::is_nothrow_swappable<E>::value) {
+        if (has_value() && rhs.has_value()) {
+            swap_where_both_have_value(rhs, typename std::is_void<T>::type{});
+        } else if (!has_value() && rhs.has_value()) {
+            rhs.swap(*this);
+        } else if (has_value()) {
+            swap_where_only_one_has_value(rhs, typename std::is_void<T>::type{});
+        } else {
+            using std::swap;
+            swap(err(), rhs.err());
+        }
+    }
+
+    constexpr const T *operator->() const {
+        BOOST_CRYPT_ASSERT(has_value());
+        return valptr();
+    }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR T *operator->() {
+        BOOST_CRYPT_ASSERT(has_value());
+        return valptr();
+    }
+
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    constexpr const U &operator*() const & {
+        BOOST_CRYPT_ASSERT(has_value());
+        return val();
+    }
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR U &operator*() & {
+        BOOST_CRYPT_ASSERT(has_value());
+        return val();
+    }
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    constexpr const U &&operator*() const && {
+        BOOST_CRYPT_ASSERT(has_value());
+        return std::move(val());
+    }
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR U &&operator*() && {
+        BOOST_CRYPT_ASSERT(has_value());
+        return std::move(val());
+    }
+
+    constexpr bool has_value() const noexcept { return this->m_has_val; }
+    constexpr explicit operator bool() const noexcept { return this->m_has_val; }
+
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR const U &value() const & {
+        if (!has_value())
+            detail::throw_exception(bad_expected_access<E>(err().value()));
+        return val();
+    }
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR U &value() & {
+        if (!has_value())
+            detail::throw_exception(bad_expected_access<E>(err().value()));
+        return val();
+    }
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR const U &&value() const && {
+        if (!has_value())
+            detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
+        return std::move(val());
+    }
+    template <class U = T,
+            detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR U &&value() && {
+        if (!has_value())
+            detail::throw_exception(bad_expected_access<E>(std::move(err()).value()));
+        return std::move(val());
+    }
+
+    constexpr const E &error() const & {
+        BOOST_CRYPT_ASSERT(!has_value());
+        return err().value();
+    }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR E &error() & {
+        BOOST_CRYPT_ASSERT(!has_value());
+        return err().value();
+    }
+    constexpr const E &&error() const && {
+        BOOST_CRYPT_ASSERT(!has_value());
+        return std::move(err().value());
+    }
+    BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR E &&error() && {
+        BOOST_CRYPT_ASSERT(!has_value());
+        return std::move(err().value());
+    }
+
+    template <class U> constexpr T value_or(U &&v) const & {
+        static_assert(std::is_copy_constructible<T>::value &&
+                      std::is_convertible<U &&, T>::value,
+                      "T must be copy-constructible and convertible to from U&&");
+        return bool(*this) ? **this : static_cast<T>(std::forward<U>(v));
+    }
+    template <class U> BOOST_CRYPT_TL_EXPECTED_11_CONSTEXPR T value_or(U &&v) && {
+        static_assert(std::is_move_constructible<T>::value &&
+                      std::is_convertible<U &&, T>::value,
+                      "T must be move-constructible and convertible to from U&&");
+        return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(v));
+    }
+};
+
+namespace detail {
+template <class Exp> using exp_t = typename detail::decay_t<Exp>::value_type;
+template <class Exp> using err_t = typename detail::decay_t<Exp>::error_type;
+template <class Exp, class Ret> using ret_t = expected<Ret, err_t<Exp>>;
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_CXX14
+template <class Exp, class F,
+        detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            *std::declval<Exp>()))>
+constexpr auto and_then_impl(Exp &&exp, F &&f) {
+    static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+
+    return exp.has_value()
+           ? detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
+           : Ret(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+        detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>()))>
+constexpr auto and_then_impl(Exp &&exp, F &&f) {
+    static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+
+    return exp.has_value() ? detail::invoke(std::forward<F>(f))
+                           : Ret(unexpect, std::forward<Exp>(exp).error());
+}
+#else
+template <class> struct TC;
+template <class Exp, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Exp>())),
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr>
+auto and_then_impl(Exp &&exp, F &&f) -> Ret {
+  static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+
+  return exp.has_value()
+             ? detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp))
+             : Ret(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>())),
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr>
+constexpr auto and_then_impl(Exp &&exp, F &&f) -> Ret {
+  static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+
+  return exp.has_value() ? detail::invoke(std::forward<F>(f))
+                         : Ret(unexpect, std::forward<Exp>(exp).error());
+}
+#endif
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_CXX14
+template <class Exp, class F,
+        detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            *std::declval<Exp>())),
+        detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto expected_map_impl(Exp &&exp, F &&f) {
+    using result = ret_t<Exp, detail::decay_t<Ret>>;
+    return exp.has_value() ? result(detail::invoke(std::forward<F>(f),
+                                                   *std::forward<Exp>(exp)))
+                           : result(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+        detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            *std::declval<Exp>())),
+        detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto expected_map_impl(Exp &&exp, F &&f) {
+    using result = expected<void, err_t<Exp>>;
+    if (exp.has_value()) {
+        detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
+        return result();
+    }
+
+    return result(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+        detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>())),
+        detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto expected_map_impl(Exp &&exp, F &&f) {
+    using result = ret_t<Exp, detail::decay_t<Ret>>;
+    return exp.has_value() ? result(detail::invoke(std::forward<F>(f)))
+                           : result(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+        detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>())),
+        detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto expected_map_impl(Exp &&exp, F &&f) {
+    using result = expected<void, err_t<Exp>>;
+    if (exp.has_value()) {
+        detail::invoke(std::forward<F>(f));
+        return result();
+    }
+
+    return result(unexpect, std::forward<Exp>(exp).error());
+}
+#else
+template <class Exp, class F,
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Exp>())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+
+constexpr auto expected_map_impl(Exp &&exp, F &&f)
+    -> ret_t<Exp, detail::decay_t<Ret>> {
+  using result = ret_t<Exp, detail::decay_t<Ret>>;
+
+  return exp.has_value() ? result(detail::invoke(std::forward<F>(f),
+                                                 *std::forward<Exp>(exp)))
+                         : result(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Exp>())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+
+auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
+  if (exp.has_value()) {
+    detail::invoke(std::forward<F>(f), *std::forward<Exp>(exp));
+    return {};
+  }
+
+  return unexpected<err_t<Exp>>(std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+
+constexpr auto expected_map_impl(Exp &&exp, F &&f)
+    -> ret_t<Exp, detail::decay_t<Ret>> {
+  using result = ret_t<Exp, detail::decay_t<Ret>>;
+
+  return exp.has_value() ? result(detail::invoke(std::forward<F>(f)))
+                         : result(unexpect, std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+
+auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
+  if (exp.has_value()) {
+    detail::invoke(std::forward<F>(f));
+    return {};
+  }
+
+  return unexpected<err_t<Exp>>(std::forward<Exp>(exp).error());
+}
+#endif
+
+#if defined(BOOST_CRYPT_TL_EXPECTED_CXX14) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC49) &&               \
+    !defined(BOOST_CRYPT_TL_EXPECTED_GCC54) && !defined(BOOST_CRYPT_TL_EXPECTED_GCC55)
+template <class Exp, class F,
+        detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            std::declval<Exp>().error())),
+        detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto map_error_impl(Exp &&exp, F &&f) {
+    using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+    return exp.has_value()
+           ? result(*std::forward<Exp>(exp))
+           : result(unexpect, detail::invoke(std::forward<F>(f),
+                                             std::forward<Exp>(exp).error()));
+}
+template <class Exp, class F,
+        detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            std::declval<Exp>().error())),
+        detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto map_error_impl(Exp &&exp, F &&f) {
+    using result = expected<exp_t<Exp>, monostate>;
+    if (exp.has_value()) {
+        return result(*std::forward<Exp>(exp));
+    }
+
+    detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+    return result(unexpect, monostate{});
+}
+template <class Exp, class F,
+        detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            std::declval<Exp>().error())),
+        detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto map_error_impl(Exp &&exp, F &&f) {
+    using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+    return exp.has_value()
+           ? result()
+           : result(unexpect, detail::invoke(std::forward<F>(f),
+                                             std::forward<Exp>(exp).error()));
+}
+template <class Exp, class F,
+        detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            std::declval<Exp>().error())),
+        detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto map_error_impl(Exp &&exp, F &&f) {
+    using result = expected<exp_t<Exp>, monostate>;
+    if (exp.has_value()) {
+        return result();
+    }
+
+    detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+    return result(unexpect, monostate{});
+}
+#else
+template <class Exp, class F,
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              std::declval<Exp>().error())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto map_error_impl(Exp &&exp, F &&f)
+    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
+  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+
+  return exp.has_value()
+             ? result(*std::forward<Exp>(exp))
+             : result(unexpect, detail::invoke(std::forward<F>(f),
+                                               std::forward<Exp>(exp).error()));
+}
+
+template <class Exp, class F,
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              std::declval<Exp>().error())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
+  using result = expected<exp_t<Exp>, monostate>;
+  if (exp.has_value()) {
+    return result(*std::forward<Exp>(exp));
+  }
+
+  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+  return result(unexpect, monostate{});
+}
+
+template <class Exp, class F,
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              std::declval<Exp>().error())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto map_error_impl(Exp &&exp, F &&f)
+    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
+  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
+
+  return exp.has_value()
+             ? result()
+             : result(unexpect, detail::invoke(std::forward<F>(f),
+                                               std::forward<Exp>(exp).error()));
+}
+
+template <class Exp, class F,
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              std::declval<Exp>().error())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
+  using result = expected<exp_t<Exp>, monostate>;
+  if (exp.has_value()) {
+    return result();
+  }
+
+  detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
+  return result(unexpect, monostate{});
+}
+#endif
+
+#ifdef BOOST_CRYPT_TL_EXPECTED_CXX14
+template <class Exp, class F,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            std::declval<Exp>().error())),
+        detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto or_else_impl(Exp &&exp, F &&f) {
+    static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+    return exp.has_value() ? std::forward<Exp>(exp)
+                           : detail::invoke(std::forward<F>(f),
+                                            std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+        class Ret = decltype(detail::invoke(std::declval<F>(),
+                                            std::declval<Exp>().error())),
+        detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+detail::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
+    return exp.has_value() ? std::forward<Exp>(exp)
+                           : (detail::invoke(std::forward<F>(f),
+                                             std::forward<Exp>(exp).error()),
+                    std::forward<Exp>(exp));
+}
+#else
+template <class Exp, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              std::declval<Exp>().error())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+auto or_else_impl(Exp &&exp, F &&f) -> Ret {
+  static_assert(detail::is_expected<Ret>::value, "F must return an expected");
+  return exp.has_value() ? std::forward<Exp>(exp)
+                         : detail::invoke(std::forward<F>(f),
+                                          std::forward<Exp>(exp).error());
+}
+
+template <class Exp, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              std::declval<Exp>().error())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+detail::decay_t<Exp> or_else_impl(Exp &&exp, F &&f) {
+  return exp.has_value() ? std::forward<Exp>(exp)
+                         : (detail::invoke(std::forward<F>(f),
+                                           std::forward<Exp>(exp).error()),
+                            std::forward<Exp>(exp));
+}
+#endif
+} // namespace detail
+
+template <class T, class E, class U, class F>
+constexpr bool operator==(const expected<T, E> &lhs,
+                          const expected<U, F> &rhs) {
+    return (lhs.has_value() != rhs.has_value())
+           ? false
+           : (!lhs.has_value() ? lhs.error() == rhs.error() : *lhs == *rhs);
+}
+template <class T, class E, class U, class F>
+constexpr bool operator!=(const expected<T, E> &lhs,
+                          const expected<U, F> &rhs) {
+    return (lhs.has_value() != rhs.has_value())
+           ? true
+           : (!lhs.has_value() ? lhs.error() != rhs.error() : *lhs != *rhs);
+}
+template <class E, class F>
+constexpr bool operator==(const expected<void, E> &lhs,
+                          const expected<void, F> &rhs) {
+    return (lhs.has_value() != rhs.has_value())
+           ? false
+           : (!lhs.has_value() ? lhs.error() == rhs.error() : true);
+}
+template <class E, class F>
+constexpr bool operator!=(const expected<void, E> &lhs,
+                          const expected<void, F> &rhs) {
+    return (lhs.has_value() != rhs.has_value())
+           ? true
+           : (!lhs.has_value() ? lhs.error() == rhs.error() : false);
+}
+
+template <class T, class E, class U>
+constexpr bool operator==(const expected<T, E> &x, const U &v) {
+    return x.has_value() ? *x == v : false;
+}
+template <class T, class E, class U>
+constexpr bool operator==(const U &v, const expected<T, E> &x) {
+    return x.has_value() ? *x == v : false;
+}
+template <class T, class E, class U>
+constexpr bool operator!=(const expected<T, E> &x, const U &v) {
+    return x.has_value() ? *x != v : true;
+}
+template <class T, class E, class U>
+constexpr bool operator!=(const U &v, const expected<T, E> &x) {
+    return x.has_value() ? *x != v : true;
+}
+
+template <class T, class E>
+constexpr bool operator==(const expected<T, E> &x, const unexpected<E> &e) {
+    return x.has_value() ? false : x.error() == e.value();
+}
+template <class T, class E>
+constexpr bool operator==(const unexpected<E> &e, const expected<T, E> &x) {
+    return x.has_value() ? false : x.error() == e.value();
+}
+template <class T, class E>
+constexpr bool operator!=(const expected<T, E> &x, const unexpected<E> &e) {
+    return x.has_value() ? true : x.error() != e.value();
+}
+template <class T, class E>
+constexpr bool operator!=(const unexpected<E> &e, const expected<T, E> &x) {
+    return x.has_value() ? true : x.error() != e.value();
+}
+
+template <class T, class E,
+        detail::enable_if_t<(std::is_void<T>::value ||
+                             std::is_move_constructible<T>::value) &&
+                            detail::is_swappable<T>::value &&
+                            std::is_move_constructible<E>::value &&
+                            detail::is_swappable<E>::value> * = nullptr>
+void swap(expected<T, E> &lhs,
+          expected<T, E> &rhs) noexcept(noexcept(lhs.swap(rhs))) {
+    lhs.swap(rhs);
+}
+} // namespace tl
+
+// LCOV_EXCL_STOP
+
+#endif

--- a/include/boost/crypt2/detail/expected.hpp
+++ b/include/boost/crypt2/detail/expected.hpp
@@ -624,7 +624,7 @@ template <class T, class E> struct expected_storage_base<T, E, false, true> {
 
 // `T` is `void`, `E` is trivially-destructible
 template <class E> struct expected_storage_base<void, E, false, true> {
-    #if __GNUC__ <= 5
+    #if defined(__GNUC__) && __GNUC__ <= 5
     //no constexpr for GCC 4/5 bug
     #else
     BOOST_CRYPT_TL_EXPECTED_MSVC2015_CONSTEXPR

--- a/include/boost/crypt2/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt2/hash/detail/sha512_base.hpp
@@ -13,6 +13,7 @@
 #include <boost/crypt2/detail/clear_mem.hpp>
 #include <boost/crypt2/detail/concepts.hpp>
 #include <boost/crypt2/detail/assert.hpp>
+#include <boost/crypt2/detail/expected.hpp>
 #include <boost/crypt2/state.hpp>
 
 namespace boost::crypt::hash_detail {
@@ -45,7 +46,7 @@ private:
 
     BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto pad_message() noexcept -> void;
 
-    BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest_impl(compat::span<compat::byte, digest_size> data) const -> state;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest_impl(compat::span<compat::byte, digest_size> data) const -> state;
 
 public:
 
@@ -63,17 +64,19 @@ public:
     BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto finalize() noexcept -> state;
 
     [[nodiscard("Digest is the function return value")]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
-    auto get_digest() const noexcept -> return_type;
+    auto get_digest() const noexcept -> compat::expected<return_type, state>;
 
-    BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest(compat::span<compat::byte> data) const noexcept -> state;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+    auto get_digest(compat::span<compat::byte> data) const noexcept -> compat::expected<return_type, state>;
 
     template <concepts::writable_output_range Range>
-    BOOST_CRYPT_GPU_ENABLED auto get_digest(Range&& data) const noexcept -> state;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED auto get_digest(Range&& data) const noexcept -> compat::expected<return_type, state>;
 };
 
 template <compat::size_t digest_size>
 template <concepts::writable_output_range Range>
-BOOST_CRYPT_GPU_ENABLED auto sha512_base<digest_size>::get_digest(Range&& data) const noexcept -> state
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED
+auto sha512_base<digest_size>::get_digest(Range&& data) const noexcept -> compat::expected<return_type, state>
 {
     using value_type = compat::range_value_t<Range>;
 
@@ -81,7 +84,7 @@ BOOST_CRYPT_GPU_ENABLED auto sha512_base<digest_size>::get_digest(Range&& data) 
 
     if (data_span.size() * sizeof(value_type) < digest_size)
     {
-        return state::insufficient_output_length;
+        return compat::unexpected(state::insufficient_output_length);
     }
 
     #if defined(__clang__) && __clang_major__ >= 19
@@ -100,7 +103,8 @@ BOOST_CRYPT_GPU_ENABLED auto sha512_base<digest_size>::get_digest(Range&& data) 
 }
 
 template <compat::size_t digest_size>
-BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512_base<digest_size>::get_digest(compat::span<compat::byte> data) const noexcept -> state
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha512_base<digest_size>::get_digest(compat::span<compat::byte> data) const noexcept -> compat::expected<return_type, state>
 {
     if (data.size() >= digest_size)
     {
@@ -117,15 +121,24 @@ BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512_base<digest_size>::get_digest(comp
         #endif
     }
 
-    return state::insufficient_output_length;
+    return compat::unexpected(state::insufficient_output_length);
 }
 
 template <compat::size_t digest_size>
-BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512_base<digest_size>::get_digest() const noexcept -> sha512_base::return_type
+[[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha512_base<digest_size>::get_digest() const noexcept -> compat::expected<return_type, state>
 {
     return_type digest {};
-    get_digest_impl(digest);
-    return digest;
+    const auto return_status {get_digest_impl(digest)};
+
+    if (return_status == state::success)
+    {
+        return digest;
+    }
+    else
+    {
+        return compat::unexpected(return_status);
+    }
 }
 
 template <compat::size_t digest_size>

--- a/include/boost/crypt2/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt2/hash/detail/sha512_base.hpp
@@ -84,7 +84,7 @@ auto sha512_base<digest_size>::get_digest(Range&& data) const noexcept -> compat
 
     if (data_span.size() * sizeof(value_type) < digest_size)
     {
-        return compat::unexpected(state::insufficient_output_length);
+        return compat::unexpected<state>(state::insufficient_output_length);
     }
 
     #if defined(__clang__) && __clang_major__ >= 19
@@ -121,7 +121,7 @@ auto sha512_base<digest_size>::get_digest(compat::span<compat::byte> data) const
         #endif
     }
 
-    return compat::unexpected(state::insufficient_output_length);
+    return compat::unexpected<state>(state::insufficient_output_length);
 }
 
 template <compat::size_t digest_size>
@@ -137,7 +137,7 @@ auto sha512_base<digest_size>::get_digest() const noexcept -> compat::expected<r
     }
     else
     {
-        return compat::unexpected(return_status);
+        return compat::unexpected<state>(return_status);
     }
 }
 

--- a/include/boost/crypt2/hash/detail/sha512_base.hpp
+++ b/include/boost/crypt2/hash/detail/sha512_base.hpp
@@ -160,7 +160,7 @@ BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512_base<digest_size>::get_digest_impl
 }
 
 template <compat::size_t digest_size>
-constexpr auto sha512_base<digest_size>::finalize() noexcept -> state
+BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512_base<digest_size>::finalize() noexcept -> state
 {
     if (computed_)
     {

--- a/include/boost/crypt2/hash/detail/sha_1_2_hasher_base.hpp
+++ b/include/boost/crypt2/hash/detail/sha_1_2_hasher_base.hpp
@@ -38,7 +38,7 @@ protected:
 
     [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto update(compat::span<const compat::byte> data) noexcept -> state;
 
-    BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest_impl(compat::span<compat::byte, digest_size> data) const noexcept -> state;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest_impl(compat::span<compat::byte, digest_size> data) const noexcept -> state;
 
 public:
 
@@ -55,18 +55,18 @@ public:
     BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto finalize() noexcept -> state;
 
     // TODO(mborland): Allow this to take dynamic extent, check the length and then use a fixed amount. See sha512_base
-    [[nodiscard("Digest is the function return value")]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest() noexcept -> return_type;
-    BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest(compat::span<compat::byte> data) const noexcept -> state;
+    [[nodiscard("Digest is the function return value")]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest() noexcept -> compat::expected<return_type, state>;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest(compat::span<compat::byte> data) const noexcept -> state;
 
     template <concepts::writable_output_range Range>
-    BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest(Range&& data) const noexcept -> void;
+    [[nodiscard]] BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto get_digest(Range&& data) const noexcept -> state;
 
     BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto base_init() noexcept -> void;
 };
 
 template <compat::size_t digest_size, compat::size_t intermediate_hash_size>
 template <concepts::writable_output_range Range>
-BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha_1_2_hasher_base<digest_size, intermediate_hash_size>::get_digest(Range&& data) const noexcept -> void
+BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha_1_2_hasher_base<digest_size, intermediate_hash_size>::get_digest(Range&& data) const noexcept -> state
 {
     using value_type = compat::range_value_t<Range>;
 
@@ -74,7 +74,7 @@ BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha_1_2_hasher_base<digest_size, intermed
 
     if (data_span.size() * sizeof(value_type) < digest_size)
     {
-        return;
+        return state::insufficient_output_length;
     }
 
     #if defined(__clang__) && __clang_major__ >= 19
@@ -90,6 +90,8 @@ BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha_1_2_hasher_base<digest_size, intermed
     #if defined(__clang__) && __clang_major__ >= 19
     #pragma clang diagnostic pop
     #endif
+
+    return state::success;
 }
 
 template <compat::size_t digest_size, compat::size_t intermediate_hash_size>
@@ -100,7 +102,7 @@ BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha_1_2_hasher_base<digest_size, intermed
         return state::state_error;
     }
 
-    for (size_t i {}; i < data.size(); ++i)
+    for (compat::size_t i {}; i < data.size(); ++i)
     {
         data[i] = static_cast<compat::byte>(intermediate_hash_[i >> 2U] >> 8U * (3U - (i & 0x03U)));
     }
@@ -132,10 +134,15 @@ sha_1_2_hasher_base<digest_size, intermediate_hash_size>::get_digest(compat::spa
 
 template <compat::size_t digest_size, compat::size_t intermediate_hash_size>
 BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto
-sha_1_2_hasher_base<digest_size, intermediate_hash_size>::get_digest() noexcept -> sha_1_2_hasher_base::return_type
+sha_1_2_hasher_base<digest_size, intermediate_hash_size>::get_digest() noexcept -> compat::expected<return_type, state>
 {
     return_type digest {};
-    get_digest_impl(digest);
+    const auto return_state {get_digest_impl(digest)};
+    if (return_state != state::success)
+    {
+        return compat::unexpected(return_state);
+    }
+
     return digest;
 }
 

--- a/include/boost/crypt2/hash/detail/sha_1_2_hasher_base.hpp
+++ b/include/boost/crypt2/hash/detail/sha_1_2_hasher_base.hpp
@@ -140,7 +140,7 @@ sha_1_2_hasher_base<digest_size, intermediate_hash_size>::get_digest() noexcept 
     const auto return_state {get_digest_impl(digest)};
     if (return_state != state::success)
     {
-        return compat::unexpected(return_state);
+        return compat::unexpected<state>(return_state);
     }
 
     return digest;

--- a/include/boost/crypt2/hash/sha1.hpp
+++ b/include/boost/crypt2/hash/sha1.hpp
@@ -230,7 +230,8 @@ BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha1_hasher::process_message_block() noex
 }
 
 // One shot functions
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha1(compat::span<const compat::byte> data) noexcept -> sha1_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha1(compat::span<const compat::byte> data) noexcept -> compat::expected<sha1_hasher::return_type, state>
 {
     sha1_hasher hasher;
     hasher.process_bytes(data);
@@ -239,7 +240,8 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha1(compat::span<cons
 }
 
 template <compat::sized_range SizedRange>
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED auto sha1(SizedRange&& data) noexcept -> sha1_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED
+auto sha1(SizedRange&& data) noexcept -> compat::expected<sha1_hasher::return_type, state>
 {
     sha1_hasher hasher;
     hasher.process_bytes(data);
@@ -260,7 +262,7 @@ namespace detail {
 #endif
 
 template <std::size_t block_size = 64U>
-auto sha1_file_impl(detail::file_reader<block_size>& reader) -> sha1_hasher::return_type
+[[nodiscard]] auto sha1_file_impl(detail::file_reader<block_size>& reader) -> compat::expected<sha1_hasher::return_type, state>
 {
     sha1_hasher hasher;
     while (!reader.eof())
@@ -282,7 +284,8 @@ auto sha1_file_impl(detail::file_reader<block_size>& reader) -> sha1_hasher::ret
 } // namespace detail
 
 template <concepts::file_system_path T>
-BOOST_CRYPT_EXPORT inline auto sha1_file(const T& filepath)
+[[nodiscard]] BOOST_CRYPT_EXPORT inline
+auto sha1_file(const T& filepath) -> compat::expected<sha1_hasher::return_type, state>
 {
     if constexpr (std::is_pointer_v<std::remove_cvref_t<T>>)
     {

--- a/include/boost/crypt2/hash/sha224.hpp
+++ b/include/boost/crypt2/hash/sha224.hpp
@@ -18,7 +18,8 @@ namespace boost::crypt {
 BOOST_CRYPT_EXPORT using sha224_hasher = hash_detail::sha_224_256_hasher<28U>;
 
 // One shot functions
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha224(compat::span<const compat::byte> data) noexcept -> sha224_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha224(compat::span<const compat::byte> data) noexcept -> compat::expected<sha224_hasher::return_type, state>
 {
     sha224_hasher hasher;
     hasher.process_bytes(data);
@@ -27,7 +28,8 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha224(compat::span<co
 }
 
 template <compat::sized_range SizedRange>
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha224(SizedRange&& data) noexcept -> sha224_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha224(SizedRange&& data) noexcept -> compat::expected<sha224_hasher::return_type, state>
 {
     sha224_hasher hasher;
     hasher.process_bytes(data);
@@ -47,7 +49,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha224(SizedRange&& da
 
 namespace detail {
 
-inline auto sha224_file_impl(detail::file_reader<64U>& reader) -> sha224_hasher::return_type
+[[nodiscard]] inline auto sha224_file_impl(detail::file_reader<64U>& reader) -> compat::expected<sha224_hasher::return_type, state>
 {
     sha224_hasher hasher;
     while (!reader.eof())
@@ -65,7 +67,7 @@ inline auto sha224_file_impl(detail::file_reader<64U>& reader) -> sha224_hasher:
 } // namespace detail
 
 template <concepts::file_system_path T>
-BOOST_CRYPT_EXPORT inline auto sha224_file(const T& filepath)
+[[nodiscard]] BOOST_CRYPT_EXPORT inline auto sha224_file(const T& filepath) -> compat::expected<sha224_hasher::return_type, state>
 {
     if constexpr (std::is_pointer_v<std::remove_cvref_t<T>>)
     {

--- a/include/boost/crypt2/hash/sha256.hpp
+++ b/include/boost/crypt2/hash/sha256.hpp
@@ -18,7 +18,8 @@ namespace boost::crypt {
 BOOST_CRYPT_EXPORT using sha256_hasher = hash_detail::sha_224_256_hasher<32U>;
 
 // One shot functions
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha256(compat::span<const compat::byte> data) noexcept -> sha256_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha256(compat::span<const compat::byte> data) noexcept -> compat::expected<sha256_hasher::return_type, state>
 {
     sha256_hasher hasher;
     hasher.process_bytes(data);
@@ -27,7 +28,8 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha256(compat::span<co
 }
 
 template <compat::sized_range SizedRange>
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha256(SizedRange&& data) noexcept -> sha256_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha256(SizedRange&& data) noexcept -> compat::expected<sha256_hasher::return_type, state>
 {
     sha256_hasher hasher;
     hasher.process_bytes(data);
@@ -47,7 +49,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha256(SizedRange&& da
 
 namespace detail {
 
-inline auto sha256_file_impl(detail::file_reader<64U>& reader) -> sha256_hasher::return_type
+[[nodiscard]] inline auto sha256_file_impl(detail::file_reader<64U>& reader) -> compat::expected<sha256_hasher::return_type, state>
 {
     sha256_hasher hasher;
     while (!reader.eof())
@@ -65,7 +67,7 @@ inline auto sha256_file_impl(detail::file_reader<64U>& reader) -> sha256_hasher:
 } // namespace detail
 
 template <concepts::file_system_path T>
-BOOST_CRYPT_EXPORT inline auto sha256_file(const T& filepath)
+[[nodiscard]] BOOST_CRYPT_EXPORT inline auto sha256_file(const T& filepath) -> compat::expected<sha256_hasher::return_type, state>
 {
     if constexpr (std::is_pointer_v<std::remove_cvref_t<T>>)
     {

--- a/include/boost/crypt2/hash/sha512.hpp
+++ b/include/boost/crypt2/hash/sha512.hpp
@@ -18,7 +18,8 @@ namespace boost::crypt {
 BOOST_CRYPT_EXPORT using sha512_hasher = hash_detail::sha512_base<64U>;
 
 // One shot functions
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512(compat::span<const compat::byte> data) noexcept -> sha512_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR
+auto sha512(compat::span<const compat::byte> data) noexcept -> compat::expected<sha512_hasher::return_type, state>
 {
     sha512_hasher hasher;
     hasher.process_bytes(data);
@@ -27,7 +28,8 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512(compat::span<co
 }
 
 template <compat::sized_range SizedRange>
-BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512(SizedRange&& data) noexcept -> sha512_hasher::return_type
+[[nodiscard]] BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED
+auto sha512(SizedRange&& data) noexcept -> compat::expected<sha512_hasher::return_type, state>
 {
     sha512_hasher hasher;
     hasher.process_bytes(data);
@@ -47,7 +49,7 @@ BOOST_CRYPT_EXPORT BOOST_CRYPT_GPU_ENABLED_CONSTEXPR auto sha512(SizedRange&& da
 
 namespace detail {
 
-inline auto sha512_file_impl(detail::file_reader<64U>& reader) -> sha512_hasher::return_type
+[[nodiscard]] inline auto sha512_file_impl(detail::file_reader<64U>& reader) -> compat::expected<sha512_hasher::return_type, state>
 {
     sha512_hasher hasher;
     while (!reader.eof())
@@ -65,7 +67,7 @@ inline auto sha512_file_impl(detail::file_reader<64U>& reader) -> sha512_hasher:
 } // namespace detail
 
 template <concepts::file_system_path T>
-BOOST_CRYPT_EXPORT inline auto sha512_file(const T& filepath)
+[[nodiscard]] BOOST_CRYPT_EXPORT inline auto sha512_file(const T& filepath) -> compat::expected<sha512_hasher::return_type, state>
 {
     if constexpr (std::is_pointer_v<std::remove_cvref_t<T>>)
     {

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -11,30 +11,46 @@ import testing ;
 
 project : requirements
 
-  <warnings>extra
+    <warnings>pedantic
 
-  # Additional flags by request
-  <toolset>gcc:<cxxflags>-Wsign-conversion
-  <toolset>gcc:<cxxflags>-Wconversion
-  <toolset>gcc:<cxxflags>-Wundef
-  <toolset>gcc:<cxxflags>-Wold-style-cast
-  <toolset>gcc:<cxxflags>-Wduplicated-branches
-  <toolset>gcc:<cxxflags>-Wfloat-equal
+    <toolset>gcc:<cxxflags>-Wsign-conversion
+    <toolset>gcc:<cxxflags>-Wconversion
+    <toolset>gcc:<cxxflags>-Wundef
+    <toolset>gcc:<cxxflags>-Wold-style-cast
+    <toolset>gcc:<cxxflags>-Wduplicated-branches
+    <toolset>gcc:<cxxflags>-Wfloat-equal
+    <toolset>gcc:<cxxflags>-Wshadow
+    <toolset>gcc:<cxxflags>-Wcast-qual
+    <toolset>gcc:<cxxflags>-Wcast-align
+    <toolset>gcc:<cxxflags>-Wlogical-op
+    <toolset>gcc:<cxxflags>-Wuseless-cast
+    <toolset>gcc:<cxxflags>-Wdouble-promotion
+    <toolset>gcc:<cxxflags>-Wformat=2
+    <toolset>gcc:<cxxflags>-Wnull-dereference
+    <toolset>gcc:<cxxflags>-Wstack-protector
+    <toolset>gcc:<cxxflags>-Wno-useless-cas
 
-  <toolset>clang:<cxxflags>-Wsign-conversion
-  <toolset>clang:<cxxflags>-Wconversion
-  <toolset>clang:<cxxflags>-Wundef
-  <toolset>clang:<cxxflags>-Wold-style-cast
-  <toolset>clang:<cxxflags>-Wfloat-equal
-  <toolset>clang-19:<cxxflags>-Wunsafe-buffer-usage
-  <toolset>clang-20:<cxxflags>-Wunsafe-buffer-usage
+    <toolset>clang:<cxxflags>-Wsign-conversion
+    <toolset>clang:<cxxflags>-Wconversion
+    <toolset>clang:<cxxflags>-Wundef
+    <toolset>clang:<cxxflags>-Wold-style-cast
+    <toolset>clang:<cxxflags>-Wfloat-equal
+    <toolset>clang:<cxxflags>-Wshadow
+    <toolset>clang:<cxxflags>-Wcast-qual
+    <toolset>clang:<cxxflags>-Wcast-align
+    <toolset>clang:<cxxflags>-Wdouble-promotion
+    <toolset>clang:<cxxflags>-Wformat=2
+    <toolset>clang:<cxxflags>-Wnull-dereference
+    <toolset>clang:<cxxflags>-Wthread-safety
+    <toolset>clang:<cxxflags>-Wunused-lambda-capture
+    <toolset>clang:<cxxflags>-Wassign-enum
 
-  <toolset>msvc:<warnings-as-errors>on
-  <toolset>clang:<warnings-as-errors>on
-  <toolset>gcc:<warnings-as-errors>on
+    <toolset>msvc:<warnings-as-errors>on
+    <toolset>clang:<warnings-as-errors>on
+    <toolset>gcc:<warnings-as-errors>on
 
-  [ requires cxx20_hdr_version cxx20_hdr_concepts cxx20_hdr_span cxx20_hdr_source_location cxx20_hdr_ranges ]
-  ;
+    [ requires cxx20_hdr_version cxx20_hdr_concepts cxx20_hdr_span cxx20_hdr_source_location cxx20_hdr_ranges ]
+    ;
 
 
 # ODR Violations

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -11,23 +11,14 @@ import testing ;
 
 project : requirements
 
-  <library>/boost/uuid//boost_uuid
-
-  <toolset>gcc:<cxxflags>-Wall
-  <toolset>gcc:<cxxflags>-Wextra
-
-  # Clang-Cl gives errors that are incorrect or irrelevant (e.g. C++98 compat)
-  #<toolset>clang:<cxxflags>-Wall
-  #<toolset>clang:<cxxflags>-Wextra
-
-  <toolset>msvc:<warnings>all
+  <warnings>extra
 
   # Additional flags by request
   <toolset>gcc:<cxxflags>-Wsign-conversion
   <toolset>gcc:<cxxflags>-Wconversion
   <toolset>gcc:<cxxflags>-Wundef
   <toolset>gcc:<cxxflags>-Wold-style-cast
-  #<toolset>gcc:<cxxflags>-Wduplicated-branches
+  <toolset>gcc:<cxxflags>-Wduplicated-branches
   <toolset>gcc:<cxxflags>-Wfloat-equal
 
   <toolset>clang:<cxxflags>-Wsign-conversion

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -23,12 +23,10 @@ project : requirements
     <toolset>gcc:<cxxflags>-Wcast-qual
     <toolset>gcc:<cxxflags>-Wcast-align
     <toolset>gcc:<cxxflags>-Wlogical-op
-    <toolset>gcc:<cxxflags>-Wuseless-cast
     <toolset>gcc:<cxxflags>-Wdouble-promotion
     <toolset>gcc:<cxxflags>-Wformat=2
     <toolset>gcc:<cxxflags>-Wnull-dereference
     <toolset>gcc:<cxxflags>-Wstack-protector
-    <toolset>gcc:<cxxflags>-Wno-useless-cas
 
     <toolset>clang:<cxxflags>-Wsign-conversion
     <toolset>clang:<cxxflags>-Wconversion

--- a/test/nvcc_jamfile
+++ b/test/nvcc_jamfile
@@ -13,7 +13,7 @@ run test_sha1_nvcc.cu ;
 run test_sha224_nvcc.cu ;
 run test_sha256_nvcc.cu ;
 #run test_sha384_nvcc.cu ;
-#run test_sha512_nvcc.cu ;
+run test_sha512_nvcc.cu ;
 #run test_sha512_224_nvcc.cu ;
 #run test_sha512_256_nvcc.cu ;
 #run test_sha3_512_nvcc.cu ;

--- a/test/test_nist_cavs_detail.hpp
+++ b/test/test_nist_cavs_detail.hpp
@@ -1861,7 +1861,7 @@ auto test_vectors_monte(const nist::cavs::test_vector_container_type& test_vecto
 
                 for (std::size_t k {}; k < result_vector.size(); ++k)
                 {
-                    Mi[k] = static_cast<std::byte>(result_vector[k]);
+                    Mi[k] = result_vector[k];
                 }
 
                 local_hasher_type this_hash { };

--- a/test/test_nist_cavs_detail.hpp
+++ b/test/test_nist_cavs_detail.hpp
@@ -809,7 +809,7 @@ auto parse_file_vectors(const std::string& test_vectors_filename, test_vector_co
             #pragma clang diagnostic pop
           #endif
 
-          length = static_cast<std::size_t>(length_from_file / 8U);
+          length = length_from_file / 8U;
         }
 
         // Get the next message.
@@ -973,7 +973,7 @@ auto parse_file_vectors_variable_xof(const std::string& test_vectors_filename, t
                     #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
                     #endif
 
-                    const auto length_from_file = static_cast<std::size_t>(std::strtoul(str_len.c_str(), nullptr, 10U));
+                    const auto length_from_file = std::strtoul(str_len.c_str(), nullptr, 10U);
 
                     #if defined(__clang__) && __clang_major__ >= 19
                     #pragma clang diagnostic pop
@@ -1152,7 +1152,7 @@ auto parse_file_monte_xof(const std::string& test_monte_filename, test_vector_co
                 {
                     const std::string str_cnt = line.substr(1U, line.length() - 1U);
 
-                    const auto len_from_file = static_cast<std::size_t>(std::strtoul(str_cnt.c_str(), nullptr, 10U));
+                    const auto len_from_file = std::strtoul(str_cnt.c_str(), nullptr, 10U);
 
                     lengths.emplace_back(len_from_file);
                 }
@@ -1829,7 +1829,7 @@ auto test_vectors_monte(const nist::cavs::test_vector_container_type& test_vecto
 
         const std::size_t copy_len
         {
-            (std::min)(static_cast<std::size_t>(MDi.size()), static_cast<std::size_t>(seed_init.size()))
+            (std::min)(MDi.size(), seed_init.size())
         };
 
         for (std::size_t i {}; i < copy_len; ++i)
@@ -1929,7 +1929,7 @@ auto test_vectors_monte_sha3(const nist::cavs::test_vector_container_type& test_
 
         const std::size_t copy_len
         {
-                (std::min)(static_cast<std::size_t>(MDi.size()), static_cast<std::size_t>(seed_init.size()))
+                (std::min)(MDi.size(), seed_init.size())
         };
 
         static_cast<void>
@@ -1991,7 +1991,7 @@ auto test_vectors_monte_xof(const nist::cavs::test_vector_container_type& test_v
 
         const std::size_t copy_len
         {
-            (std::min)(static_cast<std::size_t>(MDi.size()), static_cast<std::size_t>(seed_init.size()))
+            (std::min)(MDi.size(), seed_init.size())
         };
 
         static_cast<void>

--- a/test/test_sha1.cpp
+++ b/test/test_sha1.cpp
@@ -64,7 +64,8 @@ void basic_tests()
 {
     for (const auto& test_value : test_values)
     {
-        const auto message_result {boost::crypt::sha1(std::get<0>(test_value))};
+        const auto message_result_expected {boost::crypt::sha1(std::get<0>(test_value))};
+        const auto message_result {message_result_expected.value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -84,7 +85,8 @@ void string_test()
     for (const auto& test_value : test_values)
     {
         const std::string string_message {std::get<0>(test_value)};
-        const auto message_result {boost::crypt::sha1(string_message)};
+        const auto message_result_expected {boost::crypt::sha1(string_message)};
+        const auto message_result {message_result_expected.value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -105,7 +107,8 @@ void string_view_test()
     {
         const std::string string_message {std::get<0>(test_value)};
         const std::string_view string_view_message {string_message};
-        const auto message_result {boost::crypt::sha1(string_view_message)};
+        const auto message_result_expected {boost::crypt::sha1(string_view_message)};
+        const auto message_result {message_result_expected.value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -130,7 +133,8 @@ void test_class()
         const auto msg {std::get<0>(test_value)};
         hasher.process_bytes(msg);
         hasher.finalize();
-        const auto message_result {hasher.get_digest()};
+        const auto message_result_expected {hasher.get_digest()};
+        const auto message_result {message_result_expected.value()};
 
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
@@ -148,12 +152,14 @@ void test_class()
     const std::string bad_update_msg {"bad"};
     BOOST_TEST(hasher.process_bytes(bad_update_msg) == boost::crypt::state::state_error);
     BOOST_TEST(hasher.finalize() == boost::crypt::state::state_error);
-    BOOST_TEST(hasher.get_digest() == boost::crypt::sha1_hasher::return_type{});
+    BOOST_TEST(hasher.get_digest().error() == boost::crypt::state::state_error);
 }
 
-void test_file(const std::string& filename, const std::array<std::uint16_t, 20>& res)
+template <typename T>
+void test_file(const T& filename, const std::array<std::uint16_t, 20>& res)
 {
-    const auto crypt_res {boost::crypt::sha1_file(filename)};
+    const auto crypt_res_expected {boost::crypt::sha1_file(filename)};
+    const auto crypt_res {crypt_res_expected.value()};
 
     for (std::size_t j {}; j < crypt_res.size(); ++j)
     {
@@ -225,16 +231,14 @@ void files_test()
     const std::string str_filename {filename};
     test_file(str_filename, res);
 
-    #ifdef BOOST_CRYPT_HAS_STRING_VIEW
     const std::string_view str_view_filename {str_filename};
     test_file(str_view_filename, res);
-    #endif
 
     const auto invalid_filename = "broken.bin";
-    BOOST_TEST_THROWS(boost::crypt::sha1_file(invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash1 = boost::crypt::sha1_file(invalid_filename), std::runtime_error);
 
     const std::string str_invalid_filename {invalid_filename};
-    BOOST_TEST_THROWS(boost::crypt::sha1_file(str_invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash2 = boost::crypt::sha1_file(str_invalid_filename), std::runtime_error);
 
     // On macOS 15
     // sha1 test_file_2.txt
@@ -245,10 +249,10 @@ void files_test()
     test_file(filename_2, res_2);
 
     const char* test_null_file = nullptr;
-    BOOST_TEST_THROWS(boost::crypt::sha1_file(test_null_file), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash3 = boost::crypt::sha1_file(test_null_file), std::runtime_error);
 
     std::filesystem::path bad_path = "path.txt";
-    BOOST_TEST_THROWS(boost::crypt::sha1_file(bad_path), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash4 = boost::crypt::sha1_file(bad_path), std::runtime_error);
 }
 
 consteval bool immediate_test()
@@ -267,7 +271,8 @@ consteval bool immediate_test()
     hasher.init();
     hasher.process_bytes(byte_span);
     hasher.finalize();
-    const auto res = hasher.get_digest();
+    const auto res_expected = hasher.get_digest();
+    const auto res {res_expected.value()};
 
     bool correct {true};
     for (std::size_t i {}; i < res.size(); ++i)

--- a/test/test_sha1_nvcc.cu
+++ b/test/test_sha1_nvcc.cu
@@ -24,7 +24,7 @@ __global__ void cuda_test(char** in, digest_type* out, int numElements)
     if (i < numElements)
     {
         auto in_span {cuda::std::span(in[i], 64)};
-        out[i] = boost::crypt::sha1(in_span);
+        out[i] = boost::crypt::sha1(in_span).value();
     }
 }
 
@@ -82,7 +82,7 @@ int main()
         for(int i = 0; i < numElements; ++i)
         {
            std::span<char> in(input_vector1[i], elementSize);
-           results.emplace_back(boost::crypt::sha1(in));
+           results.emplace_back(boost::crypt::sha1(in).value());
         }
         double t = w.elapsed();
 

--- a/test/test_sha224.cpp
+++ b/test/test_sha224.cpp
@@ -43,7 +43,7 @@ void basic_tests()
 {
     for (const auto& test_value : test_values)
     {
-        const auto message_result {boost::crypt::sha224(std::get<0>(test_value))};
+        const auto message_result {boost::crypt::sha224(std::get<0>(test_value)).value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -63,7 +63,7 @@ void string_test()
     for (const auto& test_value : test_values)
     {
         const std::string string_message {std::get<0>(test_value)};
-        const auto message_result {boost::crypt::sha224(string_message)};
+        const auto message_result {boost::crypt::sha224(string_message).value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -84,7 +84,7 @@ void string_view_test()
     {
         const std::string string_message {std::get<0>(test_value)};
         const std::string_view string_view_message {string_message};
-        const auto message_result {boost::crypt::sha224(string_view_message)};
+        const auto message_result {boost::crypt::sha224(string_view_message).value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -101,7 +101,7 @@ void string_view_test()
         const auto current_state = hasher.process_bytes(string_view_message);
         BOOST_TEST(current_state == boost::crypt::state::success);
         hasher.finalize();
-        const auto result2 = hasher.get_digest();
+        const auto result2 = hasher.get_digest().value();
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
             if (!BOOST_TEST(result2[i] == static_cast<byte>(valid_result[i])))
@@ -125,7 +125,7 @@ void test_class()
         const auto msg {std::get<0>(test_value)};
         hasher.process_bytes(msg);
         hasher.finalize();
-        const auto message_result {hasher.get_digest()};
+        const auto message_result {hasher.get_digest().value()};
 
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
@@ -143,13 +143,13 @@ void test_class()
     const std::string bad_update_msg {"bad"};
     BOOST_TEST(hasher.process_bytes(bad_update_msg) == boost::crypt::state::state_error);
     BOOST_TEST(hasher.finalize() == boost::crypt::state::state_error);
-    BOOST_TEST(hasher.get_digest() == boost::crypt::sha224_hasher ::return_type{});
+    BOOST_TEST(hasher.get_digest().error() == boost::crypt::state::state_error);
 }
 
 template <typename T>
 void test_file(const T filename, const std::array<uint16_t, 28>& res)
 {
-    const auto crypt_res {boost::crypt::sha224_file(filename)};
+    const auto crypt_res {boost::crypt::sha224_file(filename).value()};
 
     for (std::size_t j {}; j < crypt_res.size(); ++j)
     {
@@ -224,10 +224,10 @@ void files_test()
     test_file(str_view_filename, res);
 
     const auto invalid_filename = "broken.bin";
-    BOOST_TEST_THROWS(boost::crypt::sha224_file(invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash1 = boost::crypt::sha224_file(invalid_filename), std::runtime_error);
 
     const std::string str_invalid_filename {invalid_filename};
-    BOOST_TEST_THROWS(boost::crypt::sha224_file(str_invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash2 = boost::crypt::sha224_file(str_invalid_filename), std::runtime_error);
 
     // On macOS 15
     // sha224 test_file_2.txt
@@ -237,10 +237,10 @@ void files_test()
     test_file(filename_2, res_2);
 
     const char* test_null_file = nullptr;
-    BOOST_TEST_THROWS(boost::crypt::sha224_file(test_null_file), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash3 = boost::crypt::sha224_file(test_null_file), std::runtime_error);
 
     std::filesystem::path bad_path = "path.txt";
-    BOOST_TEST_THROWS(boost::crypt::sha224_file(bad_path), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash4 = boost::crypt::sha224_file(bad_path), std::runtime_error);
 }
 
 consteval bool immediate_test()
@@ -259,7 +259,7 @@ consteval bool immediate_test()
     hasher.init();
     hasher.process_bytes(byte_span);
     hasher.finalize();
-    const auto res = hasher.get_digest();
+    const auto res = hasher.get_digest().value();
 
     bool correct {true};
     for (std::size_t i {}; i < res.size(); ++i)

--- a/test/test_sha224_nvcc.cu
+++ b/test/test_sha224_nvcc.cu
@@ -24,7 +24,7 @@ __global__ void cuda_test(char** in, digest_type* out, int numElements)
     if (i < numElements)
     {
         auto in_span {cuda::std::span(in[i], 64)};
-        out[i] = boost::crypt::sha224(in_span);
+        out[i] = boost::crypt::sha224(in_span).value();
     }
 }
 
@@ -82,7 +82,7 @@ int main()
         for(int i = 0; i < numElements; ++i)
         {
             std::span<char> in(input_vector1[i], elementSize);
-            results.emplace_back(boost::crypt::sha224(in));
+            results.emplace_back(boost::crypt::sha224(in).value());
         }
         double t = w.elapsed();
 

--- a/test/test_sha256_nvcc.cu
+++ b/test/test_sha256_nvcc.cu
@@ -24,7 +24,7 @@ __global__ void cuda_test(char** in, digest_type* out, int numElements)
     if (i < numElements)
     {
         auto in_span {cuda::std::span(in[i], 64)};
-        out[i] = boost::crypt::sha256(in_span);
+        out[i] = boost::crypt::sha256(in_span).value();
     }
 }
 
@@ -82,7 +82,7 @@ int main()
         for(int i = 0; i < numElements; ++i)
         {
             std::span<char> in(input_vector1[i], elementSize);
-            results.emplace_back(boost::crypt::sha256(in));
+            results.emplace_back(boost::crypt::sha256(in).value());
         }
         double t = w.elapsed();
 

--- a/test/test_sha512.cpp
+++ b/test/test_sha512.cpp
@@ -68,7 +68,7 @@ void basic_tests()
 {
     for (const auto& test_value : test_values)
     {
-        const auto message_result {boost::crypt::sha512(std::get<0>(test_value))};
+        const auto message_result {boost::crypt::sha512(std::get<0>(test_value)).value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -88,7 +88,7 @@ void string_test()
     for (const auto& test_value : test_values)
     {
         const std::string string_message {std::get<0>(test_value)};
-        const auto message_result {boost::crypt::sha512(string_message)};
+        const auto message_result {boost::crypt::sha512(string_message).value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -109,7 +109,7 @@ void string_view_test()
     {
         const std::string string_message {std::get<0>(test_value)};
         const std::string_view string_view_message {string_message};
-        const auto message_result {boost::crypt::sha512(string_view_message)};
+        const auto message_result {boost::crypt::sha512(string_view_message).value()};
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
@@ -126,7 +126,7 @@ void string_view_test()
         const auto current_state = hasher.process_bytes(string_view_message);
         BOOST_TEST(current_state == boost::crypt::state::success);
         hasher.finalize();
-        const auto result2 = hasher.get_digest();
+        const auto result2 = hasher.get_digest().value();
         for (std::size_t i {}; i < message_result.size(); ++i)
         {
             if (!BOOST_TEST(result2[i] == static_cast<byte>(valid_result[i])))
@@ -151,7 +151,7 @@ void test_class()
         const auto msg {std::get<0>(test_value)};
         hasher.process_bytes(msg);
         hasher.finalize();
-        const auto message_result {hasher.get_digest()};
+        const auto message_result {hasher.get_digest().value()};
 
         const auto valid_result {std::get<1>(test_value)};
         for (std::size_t i {}; i < message_result.size(); ++i)
@@ -169,13 +169,13 @@ void test_class()
     const std::string bad_update_msg {"bad"};
     BOOST_TEST(hasher.process_bytes(bad_update_msg) == boost::crypt::state::state_error);
     BOOST_TEST(hasher.finalize() == boost::crypt::state::state_error);
-    BOOST_TEST(hasher.get_digest() == boost::crypt::sha512_hasher::return_type{});
+    BOOST_TEST(hasher.get_digest().error() == boost::crypt::state::state_error);
 }
 
 template <typename T>
 void test_file(T filename, const std::array<uint16_t, 64U>& res)
 {
-    const auto crypt_res {boost::crypt::sha512_file(filename)};
+    const auto crypt_res {boost::crypt::sha512_file(filename).value()};
 
     for (std::size_t j {}; j < crypt_res.size(); ++j)
     {
@@ -250,13 +250,13 @@ void files_test()
     test_file(str_view_filename, res);
 
     const auto invalid_filename = "broken.bin";
-    BOOST_TEST_THROWS(boost::crypt::sha512_file(invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash1 = boost::crypt::sha512_file(invalid_filename), std::runtime_error);
 
     const std::string str_invalid_filename {invalid_filename};
-    BOOST_TEST_THROWS(boost::crypt::sha512_file(str_invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash2 =boost::crypt::sha512_file(str_invalid_filename), std::runtime_error);
 
     const std::string_view str_view_invalid_filename {str_invalid_filename};
-    BOOST_TEST_THROWS(boost::crypt::sha512_file(str_view_invalid_filename), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash3 =boost::crypt::sha512_file(str_view_invalid_filename), std::runtime_error);
     // On macOS 15
     // sha512 test_file_2.txt
     // sha512 (test_file_2.txt) = 83e18fae406f58d67f459ef301dc236639c44d4c10928e38363021ba037159e73b00a86820607a1595653129b52b284543714834816dd00a33f49cbf16ee5d77
@@ -265,10 +265,10 @@ void files_test()
     test_file(filename_2, res_2);
 
     const char* test_null_file = nullptr;
-    BOOST_TEST_THROWS(boost::crypt::sha512_file(test_null_file), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash4 =boost::crypt::sha512_file(test_null_file), std::runtime_error);
 
     std::filesystem::path bad_path = "path.txt";
-    BOOST_TEST_THROWS(boost::crypt::sha512_file(bad_path), std::runtime_error);
+    BOOST_TEST_THROWS([[maybe_unused]] const auto trash5 =boost::crypt::sha512_file(bad_path), std::runtime_error);
 }
 
 consteval bool immediate_test()
@@ -294,7 +294,7 @@ consteval bool immediate_test()
     hasher.init();
     hasher.process_bytes(byte_span);
     hasher.finalize();
-    const auto res = hasher.get_digest();
+    const auto res = hasher.get_digest().value();
 
     bool correct {true};
     for (std::size_t i {}; i < res.size(); ++i)

--- a/test/test_sha512_nvcc.cu
+++ b/test/test_sha512_nvcc.cu
@@ -14,7 +14,7 @@
 #include <memory>
 #include <span>
 
-using digest_type = cuda::std::array<cuda::std::byte, 20>;
+using digest_type = cuda::std::array<cuda::std::byte, 64>;
 
 // The kernel function
 __global__ void cuda_test(char** in, digest_type* out, int numElements)


### PR DESCRIPTION
Adds `tl::expected` so we don't have to use <expected> and a compatibility method for cuda